### PR TITLE
feat(ui): aggregator showcase polish — schema, swap card, results

### DIFF
--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -541,87 +541,52 @@
   color: var(--text-bright);
 }
 
-.wrapToggleBtn {
-  display: inline-flex;
+/* Always-visible Wrap / Unwrap mini-bar */
+.wrapBar {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr;
   align-items: center;
-  gap: 6px;
-  font-family: var(--mono);
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--accent-light);
-  background: rgba(99, 102, 241, 0.12);
-  border: 1px solid rgba(99, 102, 241, 0.35);
-  border-radius: 6px;
-  padding: 6px 12px;
-  cursor: pointer;
-  transition:
-    color 0.15s var(--ease),
-    border-color 0.15s var(--ease),
-    background 0.15s var(--ease),
-    box-shadow 0.15s var(--ease);
-  box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
-}
-
-.wrapToggleBtn:hover {
-  color: #fff;
-  background: rgba(99, 102, 241, 0.25);
-  border-color: rgba(99, 102, 241, 0.6);
-  box-shadow: 0 0 14px rgba(99, 102, 241, 0.25);
-}
-
-.wrapToggleBtn[aria-expanded="true"] {
-  color: #fff;
-  background: rgba(99, 102, 241, 0.3);
-  border-color: rgba(99, 102, 241, 0.7);
-}
-
-/* Wrap drawer (collapsed by default) */
-.wrapDrawer {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
+  gap: 8px;
+  padding: 8px 10px;
   background: var(--bg-inset);
   border: 1px solid var(--border);
   border-radius: 8px;
-  animation: slideDown 0.18s ease-out;
 }
 
-.wrapField {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.wrapInput {
-  flex: 1;
-  min-width: 0;
-  padding: 6px 9px;
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-bright);
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-}
-
-.wrapInput:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-
-.wrapFieldLabel {
+.wrapBarLabel {
   font-family: var(--mono);
   font-size: 9px;
   font-weight: 700;
   color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  width: 36px;
-  flex-shrink: 0;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+  padding-right: 4px;
+}
+
+.wrapBarRow {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.wrapInput {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-bright);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+}
+
+.wrapInput:focus {
+  outline: none;
+  border-color: var(--accent);
 }
 
 .wrapBtn {
@@ -630,19 +595,20 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--text-bright);
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 6px 12px;
+  color: var(--accent-light);
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 5px;
+  padding: 5px 9px;
   cursor: pointer;
   white-space: nowrap;
-  transition: border-color 0.15s var(--ease), background 0.15s var(--ease);
+  transition: border-color 0.15s var(--ease), background 0.15s var(--ease), color 0.15s var(--ease);
 }
 
 .wrapBtn:hover {
-  border-color: var(--accent);
-  background: var(--accent-dim);
+  color: #fff;
+  border-color: rgba(99, 102, 241, 0.6);
+  background: rgba(99, 102, 241, 0.25);
 }
 
 /* FROM / TO swap boxes */
@@ -749,7 +715,7 @@
   min-width: 0;
   padding: 0;
   font-family: var(--sans);
-  font-size: 28px;
+  font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--text-bright);
@@ -767,7 +733,7 @@
   flex: 1;
   min-width: 0;
   font-family: var(--sans);
-  font-size: 28px;
+  font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--text-bright);

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -944,6 +944,20 @@
    Step Tracker
    ══════════════════════════════════ */
 
+/* Side-by-side row: Execution Progress (left) + Aggregation Results (right) */
+.progressRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-4);
+  align-items: stretch;
+}
+
+@media (max-width: 1024px) {
+  .progressRow {
+    grid-template-columns: 1fr;
+  }
+}
+
 .trackerCard {
   background: var(--bg-card);
   border: 1px solid var(--border);

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -541,12 +541,11 @@
   color: var(--text-bright);
 }
 
-/* Always-visible Wrap / Unwrap mini-bar */
+/* Always-visible Wrap / Unwrap mini-bar — stacks vertically in narrow column */
 .wrapBar {
-  display: grid;
-  grid-template-columns: auto 1fr 1fr;
-  align-items: center;
-  gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   padding: 8px 10px;
   background: var(--bg-inset);
   border: 1px solid var(--border);
@@ -561,22 +560,21 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   white-space: nowrap;
-  padding-right: 4px;
 }
 
 .wrapBarRow {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   min-width: 0;
 }
 
 .wrapInput {
   flex: 1;
   min-width: 0;
-  padding: 5px 8px;
+  padding: 6px 8px;
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   color: var(--text-bright);
   background: var(--bg-card);
@@ -590,6 +588,8 @@
 }
 
 .wrapBtn {
+  flex-shrink: 0;
+  width: 92px;
   font-family: var(--mono);
   font-size: 9px;
   font-weight: 700;
@@ -599,7 +599,7 @@
   background: rgba(99, 102, 241, 0.1);
   border: 1px solid rgba(99, 102, 241, 0.3);
   border-radius: 5px;
-  padding: 5px 9px;
+  padding: 6px 8px;
   cursor: pointer;
   white-space: nowrap;
   transition: border-color 0.15s var(--ease), background 0.15s var(--ease), color 0.15s var(--ease);

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -1121,7 +1121,7 @@
 }
 
 /* ══════════════════════════════════
-   Under the Hood expandable
+   Under the Hood — visual explainer
    ══════════════════════════════════ */
 
 .underHood {
@@ -1133,11 +1133,6 @@
     0 1px 3px rgba(0, 0, 0, 0.24),
     0 4px 16px rgba(0, 0, 0, 0.12),
     inset 0 1px 0 rgba(255, 255, 255, 0.02);
-  transition: border-color 0.2s var(--ease);
-}
-
-.underHood:hover {
-  border-color: var(--border-bright);
 }
 
 .underHoodHeader {
@@ -1145,12 +1140,13 @@
   align-items: center;
   gap: var(--sp-3);
   width: 100%;
-  padding: var(--sp-4) var(--sp-5);
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
+  padding: 20px 28px;
   border-bottom: 1px solid var(--border);
+  background: linear-gradient(
+    180deg,
+    rgba(99, 102, 241, 0.04) 0%,
+    transparent 100%
+  );
 }
 
 .underHoodIcon {
@@ -1158,50 +1154,260 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  opacity: 0.8;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  justify-content: center;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.25);
 }
 
 .underHoodTitle {
-  flex: 1;
   font-family: var(--sans);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 16px;
+  font-weight: 700;
   color: var(--text-bright);
+  letter-spacing: -0.01em;
 }
 
-.underHoodChevron {
+.underHoodSubtitle {
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 500;
   color: var(--text-dim);
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-  transition: color 0.15s var(--ease);
+  margin-left: 4px;
 }
 
 .underHoodBody {
-  padding: var(--sp-4) var(--sp-5) var(--sp-5);
-  border-top: 1px solid var(--border);
-  animation: slideDown 0.2s ease-out;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
-.underHoodText {
+.underHoodIntro {
   font-family: var(--sans);
-  font-size: 12px;
-  color: var(--text-dim);
+  font-size: 14px;
   line-height: 1.7;
+  color: var(--text-dim);
+  margin: 0;
+  padding: 16px 20px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  border-left: 3px solid var(--accent);
 }
 
-.underHoodText strong {
+.underHoodIntro strong {
   color: var(--text-bright);
   font-weight: 600;
 }
 
-.underHoodText code {
+/* ── Hop grid (2x2 cards) ── */
+.hopGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.hopCard {
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px 20px;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.2s var(--ease);
+}
+
+.hopCard:hover {
+  border-color: var(--border-bright);
+}
+
+.hopCard::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--accent);
+  opacity: 0.8;
+}
+
+.hopCard[data-chain="L1"]::before {
+  background: linear-gradient(90deg, #6366f1, #818cf8);
+}
+
+.hopCard[data-chain="L2"]::before {
+  background: linear-gradient(90deg, #10b981, #34d399);
+}
+
+.hopCard[data-chain="L1→L2"]::before,
+.hopCard[data-chain="L2→L1"]::before {
+  background: linear-gradient(90deg, #6366f1, #22d3ee, #10b981);
+}
+
+.hopHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.hopNum {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-bright);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-bright);
+}
+
+.hopChainBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 10px;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border: 1px solid;
+}
+
+.hopChainBadge[data-chain="L1"] {
+  background: rgba(99, 102, 241, 0.15);
+  border-color: rgba(99, 102, 241, 0.35);
+  color: #a5b4fc;
+}
+
+.hopChainBadge[data-chain="L2"] {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #6ee7b7;
+}
+
+.hopChainBadge[data-chain="L1→L2"],
+.hopChainBadge[data-chain="L2→L1"] {
+  background: rgba(34, 211, 238, 0.15);
+  border-color: rgba(34, 211, 238, 0.35);
+  color: #67e8f9;
+}
+
+.hopLabel {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.hopTitle {
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-bright);
+  margin-bottom: 8px;
+  letter-spacing: -0.01em;
+}
+
+.hopBody {
+  font-family: var(--sans);
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--text-dim);
+}
+
+.hopBody strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.hopBody em {
+  color: var(--accent-light);
+  font-style: normal;
+  font-weight: 500;
+}
+
+.hopBody code {
   font-family: var(--mono);
   font-size: 10px;
   color: var(--accent-light);
   background: var(--accent-dim);
   border-radius: 3px;
-  padding: 1px 4px;
+  padding: 1px 5px;
+  white-space: nowrap;
+}
+
+/* ── Facts row ── */
+.factsRow {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+  padding: 20px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.factItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  text-align: center;
+}
+
+.factValue {
+  font-family: var(--mono);
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--accent-light);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.factLabel {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.underHoodFooter {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--text-dim);
+  margin: 0;
+  text-align: center;
+  padding: 0 20px;
+}
+
+.underHoodFooter strong {
+  color: var(--text-bright);
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .hopGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .factsRow {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 /* Reset button */

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -1430,7 +1430,7 @@
 /* ── Facts row ── */
 .factsRow {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 12px;
   padding: 20px;
   background: var(--bg-inset);

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -13,7 +13,8 @@
    Combined Hero + Viz container
    ══════════════════════════════════ */
 
-.vizContainer {
+/* Main combined card: header strip + viz + swap form, all in one container */
+.mainCard {
   position: relative;
   border-radius: var(--radius);
   background: var(--bg-card);
@@ -26,107 +27,89 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.02);
 }
 
-.hero {
-  padding: 24px 24px 16px;
-  text-align: center;
+/* Compact header strip — replaces the big hero. One row, badge + title + balances. */
+.mainHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 16px;
   border-bottom: 1px solid var(--border);
-  position: relative;
-  overflow: hidden;
+  background: linear-gradient(
+    180deg,
+    rgba(99, 102, 241, 0.04) 0%,
+    transparent 100%
+  );
+  flex-wrap: wrap;
 }
 
-.hero::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(ellipse at 15% 0%, rgba(99, 102, 241, 0.07) 0%, transparent 55%),
-    radial-gradient(ellipse at 85% 100%, rgba(34, 211, 238, 0.05) 0%, transparent 50%);
-  pointer-events: none;
-  z-index: 0;
+.mainHeaderLeft {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
-.hero > * {
-  position: relative;
-  z-index: 1;
+.mainHeaderRight {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.mainHeaderTitle {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-bright);
+  letter-spacing: -0.01em;
+}
+
+.mainHeaderStats {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.dot {
+  color: var(--border-bright);
 }
 
 .heroBadge {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 14px;
+  gap: 5px;
+  padding: 3px 10px;
   border-radius: 20px;
   background: rgba(99, 102, 241, 0.12);
   border: 1px solid rgba(99, 102, 241, 0.2);
   color: var(--accent-light);
   font-family: var(--mono);
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 8px;
-  box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.12),
-    0 0 12px rgba(99, 102, 241, 0.06);
-}
-
-.heroTitle {
-  font-family: var(--sans);
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text-bright);
-  letter-spacing: -0.02em;
-  margin: 0 0 12px;
-}
-
-.heroStats {
-  display: inline-flex;
-  align-items: center;
-  gap: 0;
-  padding: 6px 16px;
-  border-radius: var(--radius);
-  background: var(--bg-inset);
-  border: 1px solid var(--border);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.02);
-  overflow: hidden;
-}
-
-.heroStat {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 2px 16px;
-}
-
-.heroStatValue {
-  font-family: var(--mono);
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--accent-light);
-  line-height: 1;
-  letter-spacing: -0.02em;
-}
-
-.heroStatLabel {
-  font-family: var(--mono);
   font-size: 9px;
-  font-weight: 500;
-  color: var(--text-dim);
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
-.heroStatDivider {
-  width: 1px;
-  height: 32px;
-  background: var(--border);
-  flex-shrink: 0;
-}
-
 .vizInner {
   position: relative;
+}
+
+/* Inline swap form inside the merged card — no border, just a top divider */
+.swapInline {
+  border-top: 1px solid var(--border);
+  padding: 14px 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(99, 102, 241, 0.025) 100%
+  );
 }
 
 .compareBtn {
@@ -507,47 +490,11 @@
    Swap card — compact Uniswap-style
    ══════════════════════════════════ */
 
+/* Legacy swapSection kept as alias for any leftover refs — no own card */
 .swapSection {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 16px 18px;
-  box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.24),
-    0 4px 16px rgba(0, 0, 0, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.02);
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-
-/* Header row: title + balances + wrap toggle */
-.swapHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--border);
-}
-
-.swapTitle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--sans);
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--text-bright);
-  letter-spacing: -0.01em;
-}
-
-.swapHeaderBalances {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
 }
 
 .headerBalance {
@@ -574,24 +521,37 @@
 .wrapToggleBtn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--text-dim);
-  background: var(--bg-inset);
-  border: 1px solid var(--border);
+  color: var(--accent-light);
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.35);
   border-radius: 6px;
-  padding: 4px 8px;
+  padding: 6px 12px;
   cursor: pointer;
-  transition: color 0.15s var(--ease), border-color 0.15s var(--ease);
+  transition:
+    color 0.15s var(--ease),
+    border-color 0.15s var(--ease),
+    background 0.15s var(--ease),
+    box-shadow 0.15s var(--ease);
+  box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
 }
 
 .wrapToggleBtn:hover {
-  color: var(--text-bright);
-  border-color: var(--border-bright);
+  color: #fff;
+  background: rgba(99, 102, 241, 0.25);
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 14px rgba(99, 102, 241, 0.25);
+}
+
+.wrapToggleBtn[aria-expanded="true"] {
+  color: #fff;
+  background: rgba(99, 102, 241, 0.3);
+  border-color: rgba(99, 102, 241, 0.7);
 }
 
 /* Wrap drawer (collapsed by default) */

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -94,10 +94,10 @@
   letter-spacing: 0.08em;
 }
 
-/* Body grid: viz on left, swap form on right (desktop). Stacks on mobile. */
+/* Body grid: viz takes 3/4, swap form takes 1/4 (desktop). Stacks on mobile. */
 .mainBody {
   display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(320px, 1fr);
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
   gap: 0;
   align-items: stretch;
 }

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -94,13 +94,25 @@
   letter-spacing: 0.08em;
 }
 
-.vizInner {
-  position: relative;
+/* Body grid: viz on left, swap form on right (desktop). Stacks on mobile. */
+.mainBody {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(320px, 1fr);
+  gap: 0;
+  align-items: stretch;
 }
 
-/* Inline swap form inside the merged card — no border, just a top divider */
+.vizInner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+/* Inline swap form — right column on desktop, below viz on mobile */
 .swapInline {
-  border-top: 1px solid var(--border);
+  border-left: 1px solid var(--border);
   padding: 14px 18px 16px;
   display: flex;
   flex-direction: column;
@@ -110,6 +122,17 @@
     transparent 0%,
     rgba(99, 102, 241, 0.025) 100%
   );
+  min-width: 0;
+}
+
+@media (max-width: 1024px) {
+  .mainBody {
+    grid-template-columns: 1fr;
+  }
+  .swapInline {
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
 }
 
 .compareBtn {

--- a/ui/src/components/AggregatorPanel.module.css
+++ b/ui/src/components/AggregatorPanel.module.css
@@ -503,186 +503,350 @@
    Swap Section
    ══════════════════════════════════ */
 
+/* ══════════════════════════════════
+   Swap card — compact Uniswap-style
+   ══════════════════════════════════ */
+
 .swapSection {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 14px;
-  padding: var(--sp-5) var(--sp-6);
+  padding: 16px 18px;
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.24),
     0 4px 16px rgba(0, 0, 0, 0.12),
     inset 0 1px 0 rgba(255, 255, 255, 0.02);
   display: flex;
   flex-direction: column;
-  gap: var(--sp-5);
+  gap: 10px;
 }
 
-.sectionTitle {
+/* Header row: title + balances + wrap toggle */
+.swapHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.swapTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-family: var(--sans);
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 700;
   color: var(--text-bright);
-  letter-spacing: -0.02em;
-  margin-bottom: 4px;
+  letter-spacing: -0.01em;
 }
 
-.sectionDesc {
-  font-family: var(--sans);
-  font-size: 12px;
-  color: var(--text-dim);
-  line-height: 1.6;
-}
-
-/* Balance row */
-.balanceRow {
-  display: flex;
+.swapHeaderBalances {
+  display: inline-flex;
   align-items: center;
-  gap: var(--sp-4);
+  gap: 10px;
   flex-wrap: wrap;
-  padding: var(--sp-3) var(--sp-4);
-  background: var(--bg-inset);
-  border: 1px solid var(--border);
-  border-radius: 10px;
 }
 
-.balanceItem {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-  min-width: 0;
-}
-
-.balanceLabel {
+.headerBalance {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
   font-family: var(--mono);
-  font-size: 10px;
+}
+
+.headerBalanceLabel {
+  font-size: 9px;
   font-weight: 700;
   color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  flex-shrink: 0;
+  letter-spacing: 0.08em;
 }
 
-.balanceValue {
-  font-family: var(--mono);
-  font-size: 12px;
+.headerBalanceValue {
+  font-size: 11px;
   font-weight: 600;
   color: var(--text-bright);
 }
 
-.balanceSep {
-  width: 1px;
-  height: 20px;
-  background: var(--border);
-  flex-shrink: 0;
+.wrapToggleBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: color 0.15s var(--ease), border-color 0.15s var(--ease);
 }
 
-.wrapGroup {
+.wrapToggleBtn:hover {
+  color: var(--text-bright);
+  border-color: var(--border-bright);
+}
+
+/* Wrap drawer (collapsed by default) */
+.wrapDrawer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  animation: slideDown 0.18s ease-out;
+}
+
+.wrapField {
   display: flex;
   align-items: center;
-  gap: var(--sp-2);
-  margin-left: auto;
+  gap: 8px;
 }
 
 .wrapInput {
-  width: 72px;
-  padding: 5px 8px;
+  flex: 1;
+  min-width: 0;
+  padding: 6px 9px;
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   color: var(--text-bright);
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  transition:
-    border-color var(--duration) var(--ease),
-    box-shadow var(--duration) var(--ease);
+  border-radius: 6px;
 }
 
 .wrapInput:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
 }
 
-.wrapBtn {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
+.wrapFieldLabel {
   font-family: var(--mono);
   font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  color: var(--text-dim);
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 5px 8px;
-  cursor: pointer;
-  transition:
-    color var(--duration) var(--ease),
-    border-color var(--duration) var(--ease),
-    background var(--duration) var(--ease),
-    box-shadow var(--duration) var(--ease),
-    transform 0.12s var(--ease);
-  white-space: nowrap;
-}
-
-.wrapBtn:hover {
-  color: var(--text-bright);
-  border-color: var(--border-bright);
-  background: var(--overlay-subtle);
-  transform: translateY(-0.5px);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.14);
-}
-
-/* Amount input */
-.inputGroup {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-2);
-}
-
-.inputLabel {
-  font-family: var(--mono);
-  font-size: 10px;
   font-weight: 700;
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  width: 36px;
+  flex-shrink: 0;
 }
 
-.amountInput {
-  width: 100%;
-  padding: 10px 14px;
+.wrapBtn {
   font-family: var(--mono);
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   color: var(--text-bright);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s var(--ease), background 0.15s var(--ease);
+}
+
+.wrapBtn:hover {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+
+/* FROM / TO swap boxes */
+.swapBox {
   background: var(--bg-inset);
   border: 1px solid var(--border);
-  border-radius: 10px;
-  transition:
-    border-color var(--duration) var(--ease),
-    box-shadow var(--duration) var(--ease);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.15s var(--ease);
 }
 
-.amountInput:focus {
-  outline: none;
+.swapBox:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
 }
 
-/* Split slider */
+.swapBox[data-receive="true"] {
+  background: linear-gradient(180deg, var(--bg-inset) 0%, rgba(99, 102, 241, 0.04) 100%);
+}
+
+.swapBoxHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.swapBoxLabel {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.swapBoxBalance {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.maxBtn {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent-light);
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-border, rgba(99, 102, 241, 0.3));
+  border-radius: 4px;
+  padding: 1px 5px;
+  cursor: pointer;
+}
+
+.maxBtn:hover {
+  color: #fff;
+  background: var(--accent);
+}
+
+.swapBoxRoute {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.routeChip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid;
+}
+
+.routeChip[data-net="L1"] {
+  color: #a5b4fc;
+  background: rgba(99, 102, 241, 0.12);
+  border-color: rgba(99, 102, 241, 0.3);
+}
+
+.routeChip[data-net="L2"] {
+  color: #6ee7b7;
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.swapBoxRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.swapAmountInput {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  font-family: var(--sans);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-bright);
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.swapAmountInput::placeholder {
+  color: var(--text-dim);
+  opacity: 0.4;
+}
+
+.swapAmountOutput {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--sans);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-bright);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.swapTokenChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-bright);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 5px 12px 5px 10px;
+}
+
+.swapTokenDot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.swapTokenDot[data-token="weth"] {
+  background: linear-gradient(135deg, #818cf8, #6366f1);
+}
+
+.swapTokenDot[data-token="usdc"] {
+  background: linear-gradient(135deg, #34d399, #10b981);
+}
+
+.improvementRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+
+/* Split slider — compact */
 .splitGroup {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-2);
+  gap: 6px;
+  padding: 0 4px;
 }
 
 .splitLabels {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .splitLabel {
@@ -700,12 +864,21 @@
   color: var(--green);
 }
 
+.splitLabelMid {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 .splitSlider {
   -webkit-appearance: none;
   appearance: none;
   width: 100%;
-  height: 6px;
-  border-radius: 3px;
+  height: 4px;
+  border-radius: 2px;
   background: linear-gradient(
     90deg,
     rgba(99, 102, 241, 0.4) 0%,
@@ -715,14 +888,13 @@
   );
   outline: none;
   cursor: pointer;
-  transition: background 0.2s var(--ease);
 }
 
 .splitSlider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 18px;
-  height: 18px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: var(--text-bright);
   border: 2px solid var(--accent);
@@ -730,56 +902,20 @@
     0 1px 4px rgba(0, 0, 0, 0.3),
     0 0 0 2px rgba(99, 102, 241, 0.15);
   cursor: pointer;
-  transition: box-shadow 0.15s var(--ease), transform 0.15s var(--ease);
+  transition: transform 0.15s var(--ease);
 }
 
 .splitSlider::-webkit-slider-thumb:hover {
-  transform: scale(1.1);
-  box-shadow:
-    0 2px 8px rgba(0, 0, 0, 0.4),
-    0 0 0 3px rgba(99, 102, 241, 0.2);
+  transform: scale(1.15);
 }
 
 .splitSlider::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: var(--text-bright);
   border: 2px solid var(--accent);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
   cursor: pointer;
-}
-
-/* Quote preview */
-.quotePreview {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-2);
-  padding: var(--sp-3) var(--sp-4);
-  background: var(--bg-inset);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-}
-
-.quoteRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp-2);
-}
-
-.quoteLabel {
-  font-family: var(--mono);
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--text-dim);
-}
-
-.quoteValue {
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--text-bright);
 }
 
 .quoteImprovement {
@@ -789,14 +925,8 @@
   color: var(--green);
   background: var(--green-dim);
   border: 1px solid var(--green-border);
-  border-radius: var(--radius-xs);
-  padding: 2px 7px;
-}
-
-.quoteDivider {
-  height: 1px;
-  background: var(--border);
-  margin: var(--sp-1) 0;
+  border-radius: 4px;
+  padding: 1px 6px;
 }
 
 /* Execute button */

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -598,61 +598,24 @@ export function AggregatorPanel({
 
   return (
     <div className={styles.panel}>
-      {/* Hero + Visualization — single card */}
-      <div className={styles.vizContainer}>
-        {/* Hero section — inside the card, above the SVG */}
-        <div className={styles.hero}>
-          <div className={styles.heroBadge}>
-            <IconSplit size={12} />
-            Cross-Chain Aggregator
+      {/* Combined card: header strip + visualization + swap form */}
+      <div className={styles.mainCard}>
+        {/* Compact header strip: badge + title + stats + balances */}
+        <div className={styles.mainHeader}>
+          <div className={styles.mainHeaderLeft}>
+            <span className={styles.heroBadge}>
+              <IconSplit size={11} />
+              Cross-Chain Aggregator
+            </span>
+            <span className={styles.mainHeaderTitle}>Split. Swap. Atomic.</span>
+            <span className={styles.mainHeaderStats}>
+              <span>3 hops</span><span className={styles.dot}>·</span>
+              <span>2 AMMs</span><span className={styles.dot}>·</span>
+              <span>depth 7</span><span className={styles.dot}>·</span>
+              <span>1 tx</span>
+            </span>
           </div>
-          <h2 className={styles.heroTitle}>Split. Swap. Atomic.</h2>
-          <div className={styles.heroStats}>
-            <div className={styles.heroStat}>
-              <span className={styles.heroStatValue}>3</span>
-              <span className={styles.heroStatLabel}>Hops</span>
-            </div>
-            <div className={styles.heroStatDivider} />
-            <div className={styles.heroStat}>
-              <span className={styles.heroStatValue}>2</span>
-              <span className={styles.heroStatLabel}>AMMs</span>
-            </div>
-            <div className={styles.heroStatDivider} />
-            <div className={styles.heroStat}>
-              <span className={styles.heroStatValue}>7</span>
-              <span className={styles.heroStatLabel}>Depth</span>
-            </div>
-            <div className={styles.heroStatDivider} />
-            <div className={styles.heroStat}>
-              <span className={styles.heroStatValue}>1</span>
-              <span className={styles.heroStatLabel}>Transaction</span>
-            </div>
-          </div>
-        </div>
-
-        {/* SVG visualization below hero */}
-        <div className={styles.vizInner}>
-          <CrossChainFlowViz
-            vizPhase={state.vizPhase}
-            splitPercent={state.splitPercent}
-            l1ReserveA={state.l1ReserveA}
-            l1ReserveB={state.l1ReserveB}
-            l2ReserveA={state.l2ReserveA}
-            l2ReserveB={state.l2ReserveB}
-            improvement={state.improvement}
-          />
-        </div>
-      </div>
-
-      {/* Swap Section — compact Uniswap-style card */}
-      <div className={styles.swapSection}>
-        {/* Header: title + balances + wrap toggle */}
-        <div className={styles.swapHeader}>
-          <div className={styles.swapTitle}>
-            <IconSplit size={14} />
-            Aggregated Swap
-          </div>
-          <div className={styles.swapHeaderBalances}>
+          <div className={styles.mainHeaderRight}>
             <span className={styles.headerBalance}>
               <span className={styles.headerBalanceLabel}>ETH</span>
               <span className={styles.headerBalanceValue}>
@@ -674,16 +637,32 @@ export function AggregatorPanel({
             <button
               className={styles.wrapToggleBtn}
               onClick={() => setWrapOpen(!wrapOpen)}
-              title="Wrap / Unwrap ETH"
+              title="Wrap ETH ↔ WETH"
               aria-expanded={wrapOpen}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M7 16V4M7 4L3 8M7 4l4 4M17 8v12M17 20l4-4M17 20l-4-4" />
               </svg>
-              Wrap
+              Wrap ETH ↔ WETH
             </button>
           </div>
         </div>
+
+        {/* SVG visualization */}
+        <div className={styles.vizInner}>
+          <CrossChainFlowViz
+            vizPhase={state.vizPhase}
+            splitPercent={state.splitPercent}
+            l1ReserveA={state.l1ReserveA}
+            l1ReserveB={state.l1ReserveB}
+            l2ReserveA={state.l2ReserveA}
+            l2ReserveB={state.l2ReserveB}
+            improvement={state.improvement}
+          />
+        </div>
+
+        {/* Swap form — same card, separated by a thin divider */}
+        <div className={styles.swapInline}>
 
         {/* Wrap/Unwrap drawer (collapsed by default) */}
         {wrapOpen && (
@@ -816,6 +795,7 @@ export function AggregatorPanel({
             <><IconSplit size={15} /> Aggregate Swap</>
           )}
         </button>
+        </div>
       </div>
 
       {/* Contract Lanes (deployed contracts reference — less important) */}

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -495,7 +495,7 @@ function UnderTheHood() {
 
   const facts: Array<{ value: string; label: string }> = [
     { value: "1", label: "atomic tx" },
-    { value: "3", label: "cross-chain hops" },
+    { value: "2", label: "cross-chain hops" },
     { value: "7", label: "call depth" },
     { value: "2", label: "AMM pools" },
     { value: "0", label: "trust assumptions" },
@@ -570,7 +570,6 @@ export function AggregatorPanel({
 }: AggregatorPanelProps) {
   const [wrapAmount, setWrapAmount] = useState("0.1");
   const [unwrapAmount, setUnwrapAmount] = useState("0.1");
-  const [wrapOpen, setWrapOpen] = useState(false);
 
   const busy =
     state.phase !== "idle" &&
@@ -609,7 +608,7 @@ export function AggregatorPanel({
             </span>
             <span className={styles.mainHeaderTitle}>Split. Swap. Atomic.</span>
             <span className={styles.mainHeaderStats}>
-              <span>3 hops</span><span className={styles.dot}>·</span>
+              <span>2 hops</span><span className={styles.dot}>·</span>
               <span>2 AMMs</span><span className={styles.dot}>·</span>
               <span>depth 7</span><span className={styles.dot}>·</span>
               <span>1 tx</span>
@@ -634,17 +633,6 @@ export function AggregatorPanel({
                 {state.usdcBalance !== null ? parseFloat(state.usdcBalance).toFixed(2) : "—"}
               </span>
             </span>
-            <button
-              className={styles.wrapToggleBtn}
-              onClick={() => setWrapOpen(!wrapOpen)}
-              title="Wrap ETH ↔ WETH"
-              aria-expanded={wrapOpen}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M7 16V4M7 4L3 8M7 4l4 4M17 8v12M17 20l4-4M17 20l-4-4" />
-              </svg>
-              Wrap ETH ↔ WETH
-            </button>
           </div>
         </div>
 
@@ -666,37 +654,34 @@ export function AggregatorPanel({
           {/* Swap form — right column on desktop, below viz on mobile */}
           <div className={styles.swapInline}>
 
-        {/* Wrap/Unwrap drawer (collapsed by default) */}
-        {wrapOpen && (
-          <div className={styles.wrapDrawer}>
-            <div className={styles.wrapField}>
-              <input
-                type="text"
-                className={styles.wrapInput}
-                value={wrapAmount}
-                onChange={(e) => setWrapAmount(e.target.value)}
-                placeholder="0.1"
-              />
-              <span className={styles.wrapFieldLabel}>ETH</span>
-              <button className={styles.wrapBtn} onClick={() => onWrapEth(wrapAmount)}>
-                Wrap → WETH
-              </button>
-            </div>
-            <div className={styles.wrapField}>
-              <input
-                type="text"
-                className={styles.wrapInput}
-                value={unwrapAmount}
-                onChange={(e) => setUnwrapAmount(e.target.value)}
-                placeholder="0.1"
-              />
-              <span className={styles.wrapFieldLabel}>WETH</span>
-              <button className={styles.wrapBtn} onClick={() => onUnwrapWeth(unwrapAmount)}>
-                Unwrap → ETH
-              </button>
-            </div>
+        {/* Always-visible Wrap / Unwrap mini-section */}
+        <div className={styles.wrapBar}>
+          <span className={styles.wrapBarLabel}>ETH ↔ WETH</span>
+          <div className={styles.wrapBarRow}>
+            <input
+              type="text"
+              className={styles.wrapInput}
+              value={wrapAmount}
+              onChange={(e) => setWrapAmount(e.target.value)}
+              placeholder="0.1"
+            />
+            <button className={styles.wrapBtn} onClick={() => onWrapEth(wrapAmount)}>
+              Wrap →
+            </button>
           </div>
-        )}
+          <div className={styles.wrapBarRow}>
+            <input
+              type="text"
+              className={styles.wrapInput}
+              value={unwrapAmount}
+              onChange={(e) => setUnwrapAmount(e.target.value)}
+              placeholder="0.1"
+            />
+            <button className={styles.wrapBtn} onClick={() => onUnwrapWeth(unwrapAmount)}>
+              ← Unwrap
+            </button>
+          </div>
+        </div>
 
         {/* FROM box (Uniswap-style) */}
         <div className={styles.swapBox}>

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -35,6 +35,9 @@ interface AggregatorState {
   l1TxStatus: number | null;
   l1BlockNumber: number | null;
   l1GasUsed: string | null;
+  l2BlockBefore: number | null;
+  l2BlockAfter: number | null;
+  l2TxHashes: string[];
   l1Done: boolean;
   l2Done: boolean;
   localOutput: string | null;
@@ -378,15 +381,9 @@ function ResultsCard({ state }: { state: AggregatorState }) {
           <div className={styles.resultRow}>
             <span className={styles.resultLabel}>Improvement</span>
             <span className={styles.resultValue}>
-              <span className={styles.quoteImprovement}>+{state.improvement}%</span>
+              <span className={styles.quoteImprovement}>{state.improvement}</span>
               <span style={{ marginLeft: 4, fontSize: 10, color: "var(--text-dim)" }}>vs single pool</span>
             </span>
-          </div>
-        )}
-        {state.l1GasUsed && (
-          <div className={styles.resultRow}>
-            <span className={styles.resultLabel}>Gas Used</span>
-            <span className={styles.resultValue}>{state.l1GasUsed} gas</span>
           </div>
         )}
         {state.l1BlockNumber !== null && (
@@ -402,6 +399,18 @@ function ResultsCard({ state }: { state: AggregatorState }) {
             <span className={styles.resultLabel}>L1 Transaction</span>
             <span className={styles.resultValue}>
               <TxLink hash={state.txHash} chain="l1" short={false} />
+            </span>
+          </div>
+        )}
+        {state.l2TxHashes.length > 0 && (
+          <div className={styles.resultRow}>
+            <span className={styles.resultLabel}>
+              L2 {state.l2TxHashes.length === 1 ? "Transaction" : "Transactions"}
+            </span>
+            <span className={styles.resultValue} style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 2 }}>
+              {state.l2TxHashes.map((h) => (
+                <TxLink key={h} hash={h} chain="l2" short={false} />
+              ))}
             </span>
           </div>
         )}
@@ -783,24 +792,21 @@ export function AggregatorPanel({
         </div>
       </div>
 
-      {/* Contract Lanes (deployed contracts reference — less important) */}
-      <ContractLanes
-        loading={state.loading}
-        deployed={state.contractsDeployed}
-        l1Contracts={l1Contracts}
-        l2Contracts={l2Contracts}
-      />
-
-      {/* Step tracker */}
-      {showSteps && (
-        <div className={styles.trackerCard}>
-          <div className={styles.trackerTitle}>Execution Progress</div>
-          <StepTracker steps={steps} />
-          {(complete || failed) && (
-            <button className={styles.resetBtn} onClick={onReset}>
-              Reset
-            </button>
+      {/* Execution Progress + Aggregation Results — side by side row */}
+      {(showSteps || complete) && (
+        <div className={styles.progressRow}>
+          {showSteps && (
+            <div className={styles.trackerCard}>
+              <div className={styles.trackerTitle}>Execution Progress</div>
+              <StepTracker steps={steps} />
+              {(complete || failed) && (
+                <button className={styles.resetBtn} onClick={onReset}>
+                  Reset
+                </button>
+              )}
+            </div>
           )}
+          <ResultsCard state={state} />
         </div>
       )}
 
@@ -809,8 +815,13 @@ export function AggregatorPanel({
         <div className={styles.errorBanner}>{state.error}</div>
       )}
 
-      {/* Results card */}
-      <ResultsCard state={state} />
+      {/* Contract Lanes (deployed contracts reference — least important) */}
+      <ContractLanes
+        loading={state.loading}
+        deployed={state.contractsDeployed}
+        l1Contracts={l1Contracts}
+        l2Contracts={l2Contracts}
+      />
 
       {/* Under the Hood */}
       <UnderTheHood />

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -653,7 +653,7 @@ export function AggregatorPanel({
 
         {/* Always-visible Wrap / Unwrap mini-section */}
         <div className={styles.wrapBar}>
-          <span className={styles.wrapBarLabel}>ETH ↔ WETH</span>
+          <span className={styles.wrapBarLabel}>Wrap / Unwrap ETH</span>
           <div className={styles.wrapBarRow}>
             <input
               type="text"
@@ -663,7 +663,7 @@ export function AggregatorPanel({
               placeholder="0.1"
             />
             <button className={styles.wrapBtn} onClick={() => onWrapEth(wrapAmount)}>
-              Wrap →
+              ETH → WETH
             </button>
           </div>
           <div className={styles.wrapBarRow}>
@@ -675,7 +675,7 @@ export function AggregatorPanel({
               placeholder="0.1"
             />
             <button className={styles.wrapBtn} onClick={() => onUnwrapWeth(unwrapAmount)}>
-              ← Unwrap
+              WETH → ETH
             </button>
           </div>
         </div>

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -37,6 +37,7 @@ interface AggregatorState {
   l1GasUsed: string | null;
   l2BlockBefore: number | null;
   l2BlockAfter: number | null;
+  l2BlockNumber: number | null;
   l2TxHashes: string[];
   l1Done: boolean;
   l2Done: boolean;
@@ -402,15 +403,19 @@ function ResultsCard({ state }: { state: AggregatorState }) {
             </span>
           </div>
         )}
-        {state.l2TxHashes.length > 0 && (
+        {state.l2BlockNumber !== null && (
           <div className={styles.resultRow}>
-            <span className={styles.resultLabel}>
-              L2 {state.l2TxHashes.length === 1 ? "Transaction" : "Transactions"}
+            <span className={styles.resultLabel}>L2 Block</span>
+            <span className={styles.resultValue}>
+              <ExplorerLink value={state.l2BlockNumber.toString()} type="block" chain="l2" label={`#${state.l2BlockNumber}`} />
             </span>
-            <span className={styles.resultValue} style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 2 }}>
-              {state.l2TxHashes.map((h) => (
-                <TxLink key={h} hash={h} chain="l2" short={false} />
-              ))}
+          </div>
+        )}
+        {state.l2TxHashes[0] && (
+          <div className={styles.resultRow}>
+            <span className={styles.resultLabel}>L2 Transaction</span>
+            <span className={styles.resultValue}>
+              <TxLink hash={state.l2TxHashes[0]} chain="l2" short={false} />
             </span>
           </div>
         )}

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -648,21 +648,23 @@ export function AggregatorPanel({
           </div>
         </div>
 
-        {/* SVG visualization */}
-        <div className={styles.vizInner}>
-          <CrossChainFlowViz
-            vizPhase={state.vizPhase}
-            splitPercent={state.splitPercent}
-            l1ReserveA={state.l1ReserveA}
-            l1ReserveB={state.l1ReserveB}
-            l2ReserveA={state.l2ReserveA}
-            l2ReserveB={state.l2ReserveB}
-            improvement={state.improvement}
-          />
-        </div>
+        {/* Body grid: viz + swap side by side on desktop, stacked on mobile */}
+        <div className={styles.mainBody}>
+          {/* SVG visualization */}
+          <div className={styles.vizInner}>
+            <CrossChainFlowViz
+              vizPhase={state.vizPhase}
+              splitPercent={state.splitPercent}
+              l1ReserveA={state.l1ReserveA}
+              l1ReserveB={state.l1ReserveB}
+              l2ReserveA={state.l2ReserveA}
+              l2ReserveB={state.l2ReserveB}
+              improvement={state.improvement}
+            />
+          </div>
 
-        {/* Swap form — same card, separated by a thin divider */}
-        <div className={styles.swapInline}>
+          {/* Swap form — right column on desktop, below viz on mobile */}
+          <div className={styles.swapInline}>
 
         {/* Wrap/Unwrap drawer (collapsed by default) */}
         {wrapOpen && (
@@ -795,6 +797,7 @@ export function AggregatorPanel({
             <><IconSplit size={15} /> Aggregate Swap</>
           )}
         </button>
+          </div>
         </div>
       </div>
 

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -436,62 +436,131 @@ function ResultsCard({ state }: { state: AggregatorState }) {
   );
 }
 
-/* ── Under the Hood expandable ── */
+/* ── Under the Hood — visual explainer ── */
 function UnderTheHood() {
-  const [open, setOpen] = useState(false);
+  const hops: Array<{
+    num: number;
+    label: string;
+    chain: "L1" | "L2" | "L1→L2" | "L2→L1";
+    title: string;
+    body: React.ReactNode;
+  }> = [
+    {
+      num: 1,
+      label: "Local Swap",
+      chain: "L1",
+      title: "Aggregator splits your WETH",
+      body: (
+        <>
+          Your wallet sends <strong>WETH</strong> to the <strong>Aggregator</strong> contract on L1.
+          It forwards the <em>local</em> portion to the L1 AMM for an immediate WETH→USDC swap,
+          and approves the <em>remote</em> portion for the Bridge.
+        </>
+      ),
+    },
+    {
+      num: 2,
+      label: "Bridge L1→L2",
+      chain: "L1→L2",
+      title: "Cross-chain call to L2",
+      body: (
+        <>
+          The Aggregator calls <code>Bridge.bridgeTokens()</code> and then invokes the
+          <code> L2Executor</code> proxy with <code>swapAndBridgeBack()</code>. The L1 composer
+          RPC traces the transaction, queues <strong>cross-chain entries</strong> on the L2 execution
+          table, and includes them in the next L2 block — all in the same atomic tx.
+        </>
+      ),
+    },
+    {
+      num: 3,
+      label: "Remote Swap",
+      chain: "L2",
+      title: "L2 Executor runs the swap",
+      body: (
+        <>
+          On L2, the <strong>L2Executor</strong> receives <strong>wWETH</strong>, approves
+          the <strong>L2 AMM</strong>, and executes a wWETH→wUSDC swap. The L2 AMM is a
+          separate liquidity pool with its own price, giving you access to <em>two markets at once</em>.
+        </>
+      ),
+    },
+    {
+      num: 4,
+      label: "Bridge L2→L1",
+      chain: "L2→L1",
+      title: "Bounce-back to L1",
+      body: (
+        <>
+          The L2Executor immediately calls <code>Bridge.bridgeTokens()</code> to send the
+          <strong> wUSDC</strong> back to L1. This is a <strong>scope-navigation return call</strong> —
+          part of the same atomic cross-chain scope, depth 7 in the call trace. The Aggregator
+          on L1 receives the wrapped USDC as <strong>real USDC</strong> and forwards the combined
+          output to your wallet.
+        </>
+      ),
+    },
+  ];
+
+  const facts: Array<{ value: string; label: string }> = [
+    { value: "1", label: "atomic tx" },
+    { value: "3", label: "cross-chain hops" },
+    { value: "7", label: "call depth" },
+    { value: "2", label: "AMM pools" },
+    { value: "0", label: "trust assumptions" },
+  ];
 
   return (
     <div className={styles.underHood}>
-      <button
-        className={styles.underHoodHeader}
-        onClick={() => setOpen(!open)}
-        aria-expanded={open}
-      >
+      <div className={styles.underHoodHeader}>
         <span className={styles.underHoodIcon}>
           <IconSplit size={16} />
         </span>
         <span className={styles.underHoodTitle}>Under the Hood</span>
-        <span className={styles.underHoodChevron} data-open={open ? "true" : "false"}>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
+        <span className={styles.underHoodSubtitle}>
+          How a single transaction orchestrates a cross-chain swap
         </span>
-      </button>
-      {open && (
-        <div className={styles.underHoodBody}>
-          <div className={styles.underHoodText}>
-            <p>
-              <strong>3 cross-chain hops, 2 AMMs, depth 7, 1 atomic transaction.</strong>
-            </p>
-            <p style={{ marginTop: 8 }}>
-              The aggregator splits your WETH swap across two liquidity pools on different chains
-              to achieve better execution than either pool alone. Here is what happens inside:
-            </p>
-            <ol style={{ marginTop: 8, paddingLeft: 20, display: "flex", flexDirection: "column", gap: 4 }}>
-              <li>
-                <strong>Hop 1 (L1):</strong> The Aggregator contract receives your WETH, sends a portion
-                to the L1 AMM for a local swap (WETH to USDC), and bridges the remaining portion to L2
-                via <code>bridgeTokens</code>.
-              </li>
-              <li>
-                <strong>Hop 2 (L1 to L2):</strong> The cross-chain composer detects the bridge call, creates
-                execution table entries, and the builder includes them in the next L2 block. The L2Executor
-                receives wrapped WETH on L2 and swaps it through the L2 AMM.
-              </li>
-              <li>
-                <strong>Hop 3 (L2 to L1):</strong> The L2 AMM output (wrapped USDC) is bridged back to L1
-                via a scope-navigation return call. The aggregator receives both the local and remote USDC
-                outputs and forwards the total to you.
-              </li>
-            </ol>
-            <p style={{ marginTop: 8 }}>
-              The entire flow executes atomically: if any hop fails, the whole transaction reverts.
-              No funds are ever at risk. The depth-7 call trace includes: user call, aggregator dispatch,
-              L1 AMM swap, bridge out, L2 executor, L2 AMM swap, and bridge return.
-            </p>
-          </div>
+      </div>
+
+      <div className={styles.underHoodBody}>
+        <p className={styles.underHoodIntro}>
+          Cross-chain DeFi composability usually means <strong>multiple transactions</strong>,
+          bridging delays, and partial execution risk. The <strong>sync rollup protocol</strong>
+          collapses the whole flow into a <strong>single atomic L1 transaction</strong> —
+          either everything succeeds, or nothing happens.
+        </p>
+
+        <div className={styles.hopGrid}>
+          {hops.map((hop) => (
+            <div key={hop.num} className={styles.hopCard} data-chain={hop.chain}>
+              <div className={styles.hopHeader}>
+                <span className={styles.hopNum}>{hop.num}</span>
+                <span className={styles.hopChainBadge} data-chain={hop.chain}>
+                  {hop.chain}
+                </span>
+                <span className={styles.hopLabel}>{hop.label}</span>
+              </div>
+              <div className={styles.hopTitle}>{hop.title}</div>
+              <div className={styles.hopBody}>{hop.body}</div>
+            </div>
+          ))}
         </div>
-      )}
+
+        <div className={styles.factsRow}>
+          {facts.map((f) => (
+            <div key={f.label} className={styles.factItem}>
+              <div className={styles.factValue}>{f.value}</div>
+              <div className={styles.factLabel}>{f.label}</div>
+            </div>
+          ))}
+        </div>
+
+        <p className={styles.underHoodFooter}>
+          If any hop reverts, the whole scope unwinds — no leftover state on L1 or L2,
+          no tokens stranded in a bridge. That is what makes this pattern impossible on
+          traditional cross-chain messaging stacks.
+        </p>
+      </div>
     </div>
   );
 }
@@ -508,7 +577,6 @@ export function AggregatorPanel({
   walletConnected,
   walletAddress: _walletAddress,
 }: AggregatorPanelProps) {
-  const [showRouteDuel, setShowRouteDuel] = useState(false);
   const [wrapAmount, setWrapAmount] = useState("0.1");
   const [unwrapAmount, setUnwrapAmount] = useState("0.1");
 
@@ -572,14 +640,6 @@ export function AggregatorPanel({
 
         {/* SVG visualization below hero */}
         <div className={styles.vizInner}>
-          <button
-            className={styles.compareBtn}
-            data-active={showRouteDuel ? "true" : "false"}
-            onClick={() => setShowRouteDuel(!showRouteDuel)}
-            title="Toggle route comparison"
-          >
-            {showRouteDuel ? "Hide" : "Compare"}
-          </button>
           <CrossChainFlowViz
             vizPhase={state.vizPhase}
             splitPercent={state.splitPercent}
@@ -587,19 +647,10 @@ export function AggregatorPanel({
             l1ReserveB={state.l1ReserveB}
             l2ReserveA={state.l2ReserveA}
             l2ReserveB={state.l2ReserveB}
-            showRouteDuel={showRouteDuel}
             improvement={state.improvement}
           />
         </div>
       </div>
-
-      {/* Contract Lanes */}
-      <ContractLanes
-        loading={state.loading}
-        deployed={state.contractsDeployed}
-        l1Contracts={l1Contracts}
-        l2Contracts={l2Contracts}
-      />
 
       {/* Swap Section */}
       <div className={styles.swapSection}>
@@ -737,6 +788,14 @@ export function AggregatorPanel({
           )}
         </button>
       </div>
+
+      {/* Contract Lanes (deployed contracts reference — less important) */}
+      <ContractLanes
+        loading={state.loading}
+        deployed={state.contractsDeployed}
+        l1Contracts={l1Contracts}
+        l2Contracts={l2Contracts}
+      />
 
       {/* Step tracker */}
       {showSteps && (

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -82,15 +82,6 @@ function IconX({ size = 16 }: { size?: number }) {
   );
 }
 
-function IconArrowRight({ size = 16 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <line x1="5" y1="12" x2="19" y2="12" />
-      <polyline points="12 5 19 12 12 19" />
-    </svg>
-  );
-}
-
 function IconSplit({ size = 18 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -579,6 +570,7 @@ export function AggregatorPanel({
 }: AggregatorPanelProps) {
   const [wrapAmount, setWrapAmount] = useState("0.1");
   const [unwrapAmount, setUnwrapAmount] = useState("0.1");
+  const [wrapOpen, setWrapOpen] = useState(false);
 
   const busy =
     state.phase !== "idle" &&
@@ -652,80 +644,119 @@ export function AggregatorPanel({
         </div>
       </div>
 
-      {/* Swap Section */}
+      {/* Swap Section — compact Uniswap-style card */}
       <div className={styles.swapSection}>
-        <div className={styles.sectionTitle}>Aggregated Swap</div>
-        <div className={styles.sectionDesc}>
-          Split your WETH across L1 and L2 AMMs for better execution. Adjust the split ratio to optimize output.
-        </div>
-
-        {/* Balance row */}
-        <div className={styles.balanceRow}>
-          <div className={styles.balanceItem}>
-            <span className={styles.balanceLabel}>ETH</span>
-            <span className={styles.balanceValue}>
-              {state.ethBalance !== null ? parseFloat(state.ethBalance).toFixed(4) : "--"}
-            </span>
+        {/* Header: title + balances + wrap toggle */}
+        <div className={styles.swapHeader}>
+          <div className={styles.swapTitle}>
+            <IconSplit size={14} />
+            Aggregated Swap
           </div>
-          <div className={styles.balanceSep} />
-          <div className={styles.balanceItem}>
-            <span className={styles.balanceLabel}>WETH</span>
-            <span className={styles.balanceValue}>
-              {state.wethBalance !== null ? parseFloat(state.wethBalance).toFixed(4) : "--"}
+          <div className={styles.swapHeaderBalances}>
+            <span className={styles.headerBalance}>
+              <span className={styles.headerBalanceLabel}>ETH</span>
+              <span className={styles.headerBalanceValue}>
+                {state.ethBalance !== null ? parseFloat(state.ethBalance).toFixed(2) : "—"}
+              </span>
             </span>
-          </div>
-          <div className={styles.balanceSep} />
-          <div className={styles.balanceItem}>
-            <span className={styles.balanceLabel}>USDC</span>
-            <span className={styles.balanceValue}>
-              {state.usdcBalance !== null ? parseFloat(state.usdcBalance).toFixed(4) : "--"}
+            <span className={styles.headerBalance}>
+              <span className={styles.headerBalanceLabel}>WETH</span>
+              <span className={styles.headerBalanceValue}>
+                {state.wethBalance !== null ? parseFloat(state.wethBalance).toFixed(2) : "—"}
+              </span>
             </span>
-          </div>
-          <div className={styles.wrapGroup}>
-            <input
-              type="text"
-              className={styles.wrapInput}
-              value={wrapAmount}
-              onChange={(e) => setWrapAmount(e.target.value)}
-              placeholder="0.1"
-            />
-            <button className={styles.wrapBtn} onClick={() => onWrapEth(wrapAmount)}>
-              Wrap <IconArrowRight size={10} />
-            </button>
-            <input
-              type="text"
-              className={styles.wrapInput}
-              value={unwrapAmount}
-              onChange={(e) => setUnwrapAmount(e.target.value)}
-              placeholder="0.1"
-            />
-            <button className={styles.wrapBtn} onClick={() => onUnwrapWeth(unwrapAmount)}>
-              <IconArrowRight size={10} /> Unwrap
+            <span className={styles.headerBalance}>
+              <span className={styles.headerBalanceLabel}>USDC</span>
+              <span className={styles.headerBalanceValue}>
+                {state.usdcBalance !== null ? parseFloat(state.usdcBalance).toFixed(2) : "—"}
+              </span>
+            </span>
+            <button
+              className={styles.wrapToggleBtn}
+              onClick={() => setWrapOpen(!wrapOpen)}
+              title="Wrap / Unwrap ETH"
+              aria-expanded={wrapOpen}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M7 16V4M7 4L3 8M7 4l4 4M17 8v12M17 20l4-4M17 20l-4-4" />
+              </svg>
+              Wrap
             </button>
           </div>
         </div>
 
-        {/* Amount input */}
-        <div className={styles.inputGroup}>
-          <label className={styles.inputLabel} htmlFor="agg-amount">Amount (WETH)</label>
-          <input
-            id="agg-amount"
-            type="text"
-            className={styles.amountInput}
-            value={state.totalAmount}
-            onChange={(e) => onSetAmount(e.target.value)}
-            placeholder="1.0"
-          />
+        {/* Wrap/Unwrap drawer (collapsed by default) */}
+        {wrapOpen && (
+          <div className={styles.wrapDrawer}>
+            <div className={styles.wrapField}>
+              <input
+                type="text"
+                className={styles.wrapInput}
+                value={wrapAmount}
+                onChange={(e) => setWrapAmount(e.target.value)}
+                placeholder="0.1"
+              />
+              <span className={styles.wrapFieldLabel}>ETH</span>
+              <button className={styles.wrapBtn} onClick={() => onWrapEth(wrapAmount)}>
+                Wrap → WETH
+              </button>
+            </div>
+            <div className={styles.wrapField}>
+              <input
+                type="text"
+                className={styles.wrapInput}
+                value={unwrapAmount}
+                onChange={(e) => setUnwrapAmount(e.target.value)}
+                placeholder="0.1"
+              />
+              <span className={styles.wrapFieldLabel}>WETH</span>
+              <button className={styles.wrapBtn} onClick={() => onUnwrapWeth(unwrapAmount)}>
+                Unwrap → ETH
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* FROM box (Uniswap-style) */}
+        <div className={styles.swapBox}>
+          <div className={styles.swapBoxHeader}>
+            <span className={styles.swapBoxLabel}>You pay</span>
+            <span className={styles.swapBoxBalance}>
+              Balance: {state.wethBalance !== null ? parseFloat(state.wethBalance).toFixed(4) : "—"}
+              {state.wethBalance !== null && parseFloat(state.wethBalance) > 0 && (
+                <button
+                  className={styles.maxBtn}
+                  onClick={() => onSetAmount(state.wethBalance!)}
+                >
+                  MAX
+                </button>
+              )}
+            </span>
+          </div>
+          <div className={styles.swapBoxRow}>
+            <input
+              type="text"
+              className={styles.swapAmountInput}
+              value={state.totalAmount}
+              onChange={(e) => onSetAmount(e.target.value)}
+              placeholder="0.0"
+            />
+            <span className={styles.swapTokenChip}>
+              <span className={styles.swapTokenDot} data-token="weth" />
+              WETH
+            </span>
+          </div>
         </div>
 
-        {/* Split slider */}
+        {/* Split slider — compact */}
         <div className={styles.splitGroup}>
           <div className={styles.splitLabels}>
             <span className={styles.splitLabel} data-net="L1">
-              L1 Local: {state.splitPercent}%
+              L1 {state.splitPercent}%
             </span>
+            <span className={styles.splitLabelMid}>Route split</span>
             <span className={styles.splitLabel} data-net="L2">
-              L2 Remote: {100 - state.splitPercent}%
+              L2 {100 - state.splitPercent}%
             </span>
           </div>
           <input
@@ -738,43 +769,41 @@ export function AggregatorPanel({
           />
         </div>
 
-        {/* Quote preview */}
-        <div className={styles.quotePreview}>
-          <div className={styles.quoteRow}>
-            <span className={styles.quoteLabel}>L1 AMM</span>
-            <span className={styles.quoteValue}>
-              {state.l1Quote !== null ? `${state.l1Quote} USDC` : "--"}
+        {/* TO box — receive */}
+        <div className={styles.swapBox} data-receive="true">
+          <div className={styles.swapBoxHeader}>
+            <span className={styles.swapBoxLabel}>You receive</span>
+            <span className={styles.swapBoxRoute}>
+              {state.l1Quote !== null && (
+                <span className={styles.routeChip} data-net="L1">
+                  L1 {parseFloat(state.l1Quote).toFixed(2)}
+                </span>
+              )}
+              {state.l2Quote !== null && (
+                <span className={styles.routeChip} data-net="L2">
+                  L2 {parseFloat(state.l2Quote).toFixed(2)}
+                </span>
+              )}
             </span>
           </div>
-          <div className={styles.quoteRow}>
-            <span className={styles.quoteLabel}>L2 AMM</span>
-            <span className={styles.quoteValue}>
-              {state.l2Quote !== null ? `${state.l2Quote} USDC` : "--"}
-            </span>
-          </div>
-          <div className={styles.quoteDivider} />
-          <div className={styles.quoteRow}>
-            <span className={styles.quoteLabel}>Total</span>
-            <span className={styles.quoteValue}>
+          <div className={styles.swapBoxRow}>
+            <span className={styles.swapAmountOutput}>
               {state.l1Quote !== null && state.l2Quote !== null
-                ? `${(parseFloat(state.l1Quote) + parseFloat(state.l2Quote)).toFixed(4)} USDC`
-                : "--"}
+                ? (parseFloat(state.l1Quote) + parseFloat(state.l2Quote)).toFixed(4)
+                : "—"}
+            </span>
+            <span className={styles.swapTokenChip}>
+              <span className={styles.swapTokenDot} data-token="usdc" />
+              USDC
             </span>
           </div>
           {state.singlePoolQuote !== null && state.improvement !== null && (
-            <>
-              <div className={styles.quoteDivider} />
-              <div className={styles.quoteRow}>
-                <span className={styles.quoteLabel}>vs Single Pool</span>
-                <span className={styles.quoteValue}>
-                  {state.singlePoolQuote} USDC
-                  <span className={styles.quoteImprovement} style={{ marginLeft: 8 }}>+{state.improvement}%</span>
-                </span>
-              </div>
-            </>
+            <div className={styles.improvementRow}>
+              vs single pool ({parseFloat(state.singlePoolQuote).toFixed(2)} USDC):
+              <span className={styles.quoteImprovement}>+{state.improvement}%</span>
+            </div>
           )}
         </div>
-
         {/* Execute button */}
         <button
           className={styles.executeBtn}

--- a/ui/src/components/AggregatorPanel.tsx
+++ b/ui/src/components/AggregatorPanel.tsx
@@ -485,9 +485,8 @@ function UnderTheHood() {
         <>
           The L2Executor immediately calls <code>Bridge.bridgeTokens()</code> to send the
           <strong> wUSDC</strong> back to L1. This is a <strong>scope-navigation return call</strong> —
-          part of the same atomic cross-chain scope, depth 7 in the call trace. The Aggregator
-          on L1 receives the wrapped USDC as <strong>real USDC</strong> and forwards the combined
-          output to your wallet.
+          part of the same atomic cross-chain scope. The Aggregator on L1 receives the wrapped
+          USDC as <strong>real USDC</strong> and forwards the combined output to your wallet.
         </>
       ),
     },
@@ -496,7 +495,6 @@ function UnderTheHood() {
   const facts: Array<{ value: string; label: string }> = [
     { value: "1", label: "atomic tx" },
     { value: "2", label: "cross-chain hops" },
-    { value: "7", label: "call depth" },
     { value: "2", label: "AMM pools" },
     { value: "0", label: "trust assumptions" },
   ];
@@ -610,7 +608,6 @@ export function AggregatorPanel({
             <span className={styles.mainHeaderStats}>
               <span>2 hops</span><span className={styles.dot}>·</span>
               <span>2 AMMs</span><span className={styles.dot}>·</span>
-              <span>depth 7</span><span className={styles.dot}>·</span>
               <span>1 tx</span>
             </span>
           </div>

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -23,15 +23,22 @@ interface CrossChainFlowVizProps {
 
 /* ── Path data ── */
 
+// Box edges with the new 160x64 size:
+//   User    [20-180,  48-112]
+//   Agg     [220-380, 48-112]
+//   L1 AMM  [480-640, 48-112]
+//   Output  [740-900, 48-112]
+//   L2 Exec [260-420, 258-322]
+//   L2 AMM  [520-680, 258-322]
 const PATHS = {
-  userToAgg: "M160,80 L240,80",
-  aggToL1Amm: "M360,80 L500,80",
-  l1AmmToOutput: "M620,80 L760,80",
-  aggToPortalDown: "M300,105 C300,150 300,170 300,190",
-  portalToL2Exec: "M300,210 C300,240 320,270 340,290",
-  l2ExecToL2Amm: "M400,290 L540,290",
-  l2AmmToPortalUp: "M660,290 C700,260 760,230 790,210",
-  portalToOutput: "M790,190 C790,150 810,120 820,105",
+  userToAgg: "M180,80 L220,80",
+  aggToL1Amm: "M380,80 L480,80",
+  l1AmmToOutput: "M640,80 L740,80",
+  aggToPortalDown: "M300,112 C300,150 300,170 300,190",
+  portalToL2Exec: "M300,210 C300,240 320,250 340,258",
+  l2ExecToL2Amm: "M420,290 L520,290",
+  l2AmmToPortalUp: "M680,290 C700,270 770,235 790,210",
+  portalToOutput: "M790,190 C790,150 810,125 820,112",
 } as const;
 
 /* ── Colours ── */
@@ -295,15 +302,15 @@ function JourneyParticle({
  */
 const JOURNEY_PATHS = {
   preSplit: "M100,80 L300,80",
-  // Local leg
+  // Local leg — through L1 AMM center
   localToL1Amm: "M300,80 L560,80",
   localToOutput: "M560,80 L820,80",
-  // Remote leg (broken into 5 short segments to support per-segment label swaps)
-  remoteAggToPortalDown: "M300,90 L300,180",
-  remotePortalToL2Exec: "M300,200 C300,240 320,270 340,290",
+  // Remote leg — exit Aggregator from bottom (y=112), enter L2 Executor top (y=258)
+  remoteAggToPortalDown: "M300,112 L300,180",
+  remotePortalToL2Exec: "M300,200 C300,235 320,250 340,258",
   remoteL2ExecToL2Amm: "M340,290 L600,290",
-  remoteL2AmmToPortalUp: "M600,290 C700,260 760,230 790,200",
-  remotePortalToOutput: "M790,180 L820,90",
+  remoteL2AmmToPortalUp: "M600,290 C700,265 770,235 790,200",
+  remotePortalToOutput: "M790,180 L820,112",
 } as const;
 
 /* ── Coordinated Journey ──
@@ -518,11 +525,12 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }
   // BOTH pool containers have the SAME size. What changes is how full each
   // container is — the LIQUID LEVEL reflects the relative liquidity. A pool
   // with 2x more TVL than another will be visibly more full.
-  const poolW = 120;
-  const poolH = 50;
+  // Pool container size matches FlowNode (160x64) so the schema is uniform
+  const poolW = 160;
+  const poolH = 64;
   const poolX = x - poolW / 2;
   const poolY = y - poolH / 2;
-  const padding = 2;
+  const padding = 3;
   const innerW = poolW - padding * 2;
   const innerH = poolH - padding * 2;
 
@@ -689,7 +697,7 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }
             y={liquidTop + liquidH / 2 - 1}
             textAnchor="middle"
             fill="#c7d2fe"
-            fontSize={8}
+            fontSize={10}
             fontWeight={700}
             fontFamily="var(--mono)"
             opacity={0.95}
@@ -699,12 +707,12 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }
           {reserveA !== null && (
             <text
               x={poolX + padding + leftWidth / 2}
-              y={liquidTop + liquidH / 2 + 9}
+              y={liquidTop + liquidH / 2 + 11}
               textAnchor="middle"
               fill="#a5b4fc"
-              fontSize={7}
+              fontSize={9}
               fontFamily="var(--mono)"
-              opacity={0.75}
+              opacity={0.8}
             >
               {formatReserve(reserveA)}
             </text>
@@ -720,7 +728,7 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }
             y={liquidTop + liquidH / 2 - 1}
             textAnchor="middle"
             fill="#a7f3d0"
-            fontSize={8}
+            fontSize={10}
             fontWeight={700}
             fontFamily="var(--mono)"
             opacity={0.95}
@@ -730,12 +738,12 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }
           {reserveB !== null && (
             <text
               x={dividerX + rightWidth / 2}
-              y={liquidTop + liquidH / 2 + 9}
+              y={liquidTop + liquidH / 2 + 11}
               textAnchor="middle"
               fill="#6ee7b7"
-              fontSize={7}
+              fontSize={9}
               fontFamily="var(--mono)"
-              opacity={0.75}
+              opacity={0.8}
             >
               {formatReserve(reserveB)}
             </text>
@@ -793,18 +801,21 @@ function FlowNode({ x, y, label, sublabel, chain, active }: FlowNodeProps) {
   const activeStroke = chain === "l1"
     ? "var(--accent)"
     : "var(--green)";
+  // Box dimensions enlarged so the schema fills the wider 3/4 column
+  const w = 160;
+  const h = 64;
 
   return (
     <g>
       <rect
-        x={x - 60}
-        y={y - 25}
-        width={120}
-        height={50}
-        rx={8}
+        x={x - w / 2}
+        y={y - h / 2}
+        width={w}
+        height={h}
+        rx={10}
         fill="var(--bg-card)"
         stroke={active ? activeStroke : stroke}
-        strokeWidth={active ? 1.5 : 0.8}
+        strokeWidth={active ? 1.6 : 0.9}
         filter={active ? "url(#nodeGlow)" : undefined}
       />
       <text
@@ -812,19 +823,20 @@ function FlowNode({ x, y, label, sublabel, chain, active }: FlowNodeProps) {
         y={y - 4}
         textAnchor="middle"
         fill="var(--text)"
-        fontSize={11}
-        fontWeight={600}
+        fontSize={14}
+        fontWeight={700}
         fontFamily="var(--sans)"
+        letterSpacing="-0.01em"
       >
         {label}
       </text>
       {sublabel && (
         <text
           x={x}
-          y={y + 12}
+          y={y + 14}
           textAnchor="middle"
           fill="var(--text-dim)"
-          fontSize={9}
+          fontSize={10}
           fontFamily="var(--mono)"
         >
           {sublabel}
@@ -1126,35 +1138,37 @@ export function CrossChainFlowViz({
         {/* Pool labels on top of LiquidPool */}
         <text
           x={560}
-          y={57}
+          y={42}
           textAnchor="middle"
           fill="var(--text)"
-          fontSize={11}
-          fontWeight={600}
+          fontSize={13}
+          fontWeight={700}
           fontFamily="var(--sans)"
+          letterSpacing="-0.01em"
         >
           L1 AMM
         </text>
         <text
           x={600}
-          y={267}
+          y={252}
           textAnchor="middle"
           fill="var(--text)"
-          fontSize={11}
-          fontWeight={600}
+          fontSize={13}
+          fontWeight={700}
           fontFamily="var(--sans)"
+          letterSpacing="-0.01em"
         >
           L2 AMM
         </text>
 
-        {/* Aggregator breathing effect when idle */}
+        {/* Aggregator breathing effect when idle — match the new node size */}
         {vizPhase === 0 && (
           <rect
-            x={240}
-            y={55}
-            width={120}
-            height={50}
-            rx={8}
+            x={220}
+            y={48}
+            width={160}
+            height={64}
+            rx={10}
             fill="none"
             stroke="var(--accent)"
             strokeWidth={0.8}

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -160,74 +160,14 @@ function SvgDefs() {
   );
 }
 
-/* ── Particle Stream ── */
-
-interface ParticleStreamProps {
-  pathData: string;
-  color: string;
-  active: boolean;
-  count?: number;
-  speed?: number;
-  particleSize?: "small" | "normal" | "large";
-}
-
-/* Size presets: plasma radius, halo radius, core radius */
+/* ── Particle size presets ──
+ * plasma radius, halo radius, core radius
+ * Used by JourneyParticle for the 3-layer particle rendering. */
 const PARTICLE_SIZES = {
   small:  { plasma: 5,  halo: 3, core: 1   },
   normal: { plasma: 7,  halo: 4, core: 1.5 },
   large:  { plasma: 10, halo: 6, core: 2.5 },
 } as const;
-
-function ParticleStream({
-  pathData,
-  color,
-  active,
-  count = 5,
-  speed = 1.0,
-  particleSize = "normal",
-}: ParticleStreamProps) {
-  if (!active) return null;
-  const sz = PARTICLE_SIZES[particleSize];
-  return (
-    <g>
-      {Array.from({ length: count }, (_, i) => {
-        const dur = `${speed + i * 0.15}s`;
-        const begin = `${i * 0.18}s`;
-        return (
-          <g key={i}>
-            {/* Plasma tail — outermost, soft, displaced */}
-            <circle r={sz.plasma} fill={color} opacity={0.12} filter="url(#plasma)">
-              <animateMotion
-                dur={dur}
-                begin={begin}
-                repeatCount="indefinite"
-                path={pathData}
-              />
-            </circle>
-            {/* Color halo — mid-layer glow */}
-            <circle r={sz.halo} fill={color} opacity={0.35} filter="url(#glow)">
-              <animateMotion
-                dur={dur}
-                begin={begin}
-                repeatCount="indefinite"
-                path={pathData}
-              />
-            </circle>
-            {/* White core — crisp center */}
-            <circle r={sz.core} fill={COL.white} opacity={0.9}>
-              <animateMotion
-                dur={dur}
-                begin={begin}
-                repeatCount="indefinite"
-                path={pathData}
-              />
-            </circle>
-          </g>
-        );
-      })}
-    </g>
-  );
-}
 
 /* ── Ambient idle particles — slow drifting specks ── */
 
@@ -246,6 +186,219 @@ function AmbientParticles() {
       <circle r={3} fill={COL.cyan} opacity={0.3} filter="url(#glow)">
         <animateMotion dur="12s" repeatCount="indefinite" path="M250,190 C450,185 650,195 800,190" />
       </circle>
+    </g>
+  );
+}
+
+/* ── Journey Particle ── */
+
+/**
+ * A particle that travels along a single path segment, with a label following it.
+ *
+ * Drives off a master cycle: visible only between [beginOffset, beginOffset+duration]
+ * within each cycle. The animation is restarted by the master cycle's `begin` event,
+ * so the whole sequence loops smoothly forever.
+ */
+interface JourneyParticleProps {
+  path: string;
+  duration: number;
+  beginOffset: number;
+  color: string;
+  label: string;
+  labelColor: string;
+  size?: "small" | "normal" | "large";
+  /** Where to put the label relative to the particle: above (-) or below (+) */
+  labelDy?: number;
+}
+
+function JourneyParticle({
+  path,
+  duration,
+  beginOffset,
+  color,
+  label,
+  labelColor,
+  size = "normal",
+  labelDy = -12,
+}: JourneyParticleProps) {
+  const sz = PARTICLE_SIZES[size];
+  // Animations are tied to the master cycle (#cycleClock). Each cycle the particle
+  // spawns at its beginOffset, animates for `duration`, then disappears.
+  const startEvent = `cycleClock.begin+${beginOffset}s`;
+  const endEvent = `cycleClock.begin+${beginOffset + duration}s`;
+  const dur = `${duration}s`;
+
+  return (
+    <g opacity={0}>
+      {/* Master visibility — show during the segment, hide at the end */}
+      <set attributeName="opacity" to="1" begin={startEvent} />
+      <set attributeName="opacity" to="0" begin={endEvent} />
+
+      {/* Plasma tail */}
+      <circle r={sz.plasma} fill={color} opacity={0.18} filter="url(#plasma)">
+        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+      </circle>
+      {/* Color halo */}
+      <circle r={sz.halo} fill={color} opacity={0.45} filter="url(#glow)">
+        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+      </circle>
+      {/* White core */}
+      <circle r={sz.core} fill={COL.white} opacity={0.95}>
+        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+      </circle>
+
+      {/* Label — follows the particle on the same path with the same timing.
+          The text uses y={labelDy} so it sits offset above/below the moving origin. */}
+      <text
+        x={0}
+        y={labelDy}
+        fontSize={9}
+        fontWeight={700}
+        fill={labelColor}
+        textAnchor="middle"
+        fontFamily="var(--mono)"
+        filter="url(#glow)"
+        style={{ paintOrder: "stroke fill" }}
+        stroke="rgba(8,10,18,0.75)"
+        strokeWidth={2.4}
+        strokeLinejoin="round"
+      >
+        {label}
+        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+      </text>
+    </g>
+  );
+}
+
+/* ── Journey path constants ──
+ *
+ * Combined SVG path strings for each leg of the cross-chain story.
+ * The remote leg is broken into multiple segments to allow per-segment
+ * label changes (WETH → wWETH → wUSDC → USDC).
+ *
+ * Cycle layout (4s total):
+ *   t=0.0 → t=1.0  Pre-split:  User → Aggregator
+ *   t=1.0 → t=4.0  Local:      Aggregator → L1 AMM → Output (3s)
+ *   t=1.0 → t=4.0  Remote:     Aggregator → Portal → L2 Exec → L2 AMM → Portal → Output (3s)
+ *
+ * Both branches end at t=4.0 (Output) so they arrive simultaneously.
+ */
+const JOURNEY_PATHS = {
+  preSplit: "M100,80 L300,80",
+  // Local leg
+  localToL1Amm: "M300,80 L560,80",
+  localToOutput: "M560,80 L820,80",
+  // Remote leg (broken into 5 short segments to support per-segment label swaps)
+  remoteAggToPortalDown: "M300,90 L300,180",
+  remotePortalToL2Exec: "M300,200 C300,240 320,270 340,290",
+  remoteL2ExecToL2Amm: "M340,290 L600,290",
+  remoteL2AmmToPortalUp: "M600,290 C700,260 760,230 790,200",
+  remotePortalToOutput: "M790,180 L820,90",
+} as const;
+
+/* ── Coordinated Journey ──
+ *
+ * Renders the full cross-chain journey: a single particle splits at the Aggregator
+ * into local and remote branches that arrive at Output simultaneously. Loops forever.
+ */
+function CoordinatedJourney() {
+  return (
+    <g>
+      {/* Master cycle clock — drives the begin events of every segment.
+          A 4s repeating animation; each cycleClock.begin event restarts the chain. */}
+      <rect x={-10} y={-10} width={1} height={1} fill="none" opacity={0}>
+        <animate
+          id="cycleClock"
+          attributeName="opacity"
+          from="0"
+          to="0"
+          dur="4s"
+          begin="0s"
+          repeatCount="indefinite"
+        />
+      </rect>
+
+      {/* ── Phase A: Pre-split (t=0 → t=1) ── */}
+      <JourneyParticle
+        path={JOURNEY_PATHS.preSplit}
+        duration={1.0}
+        beginOffset={0}
+        color={COL.gold}
+        label="WETH"
+        labelColor={COL.gold}
+        size="large"
+        labelDy={-13}
+      />
+
+      {/* ── Phase B Local: Aggregator → L1 AMM → Output (t=1 → t=4) ──
+          Two segments: WETH (1s) then USDC (2s). */}
+      <JourneyParticle
+        path={JOURNEY_PATHS.localToL1Amm}
+        duration={1.5}
+        beginOffset={1.0}
+        color={COL.gold}
+        label="WETH"
+        labelColor={COL.gold}
+        labelDy={-12}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.localToOutput}
+        duration={1.5}
+        beginOffset={2.5}
+        color={COL.blue}
+        label="USDC"
+        labelColor={COL.blue}
+        labelDy={-12}
+      />
+
+      {/* ── Phase B Remote: Aggregator → Portal → L2 Exec → L2 AMM → Portal → Output (t=1 → t=4) ──
+          Five segments totaling 3s — same total wall-clock time as the local branch
+          even though the path is much longer. The remote particle moves visually faster. */}
+      <JourneyParticle
+        path={JOURNEY_PATHS.remoteAggToPortalDown}
+        duration={0.5}
+        beginOffset={1.0}
+        color={COL.gold}
+        label="WETH"
+        labelColor={COL.gold}
+        labelDy={-10}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remotePortalToL2Exec}
+        duration={0.5}
+        beginOffset={1.5}
+        color={COL.cyan}
+        label="wWETH"
+        labelColor={COL.cyan}
+        labelDy={-10}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remoteL2ExecToL2Amm}
+        duration={0.6}
+        beginOffset={2.0}
+        color={COL.cyan}
+        label="wWETH"
+        labelColor={COL.cyan}
+        labelDy={14}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remoteL2AmmToPortalUp}
+        duration={0.7}
+        beginOffset={2.6}
+        color={COL.cyan}
+        label="wUSDC"
+        labelColor={COL.cyan}
+        labelDy={-10}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remotePortalToOutput}
+        duration={0.7}
+        beginOffset={3.3}
+        color={COL.blue}
+        label="USDC"
+        labelColor={COL.blue}
+        labelDy={-10}
+      />
     </g>
   );
 }
@@ -359,23 +512,36 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
   const a = reserveA ? parseFloat(reserveA) : 0;
   const b = reserveB ? parseFloat(reserveB) : 0;
   const total = a + b;
-  const ratioA = total > 0 ? a / total : 0.5;
-
-  // Pool inner height is 46px (50 - 4px for padding visual), liquid fills from bottom
-  const innerH = 46;
-  const liquidAHeight = ratioA * innerH;
-  const liquidBHeight = (1 - ratioA) * innerH;
+  // Vertical split: left = token A, right = token B. Width proportional to raw token COUNT.
+  // Clamp ratio so neither side disappears entirely (5% min for each).
+  const rawRatioA = total > 0 ? a / total : 0.5;
+  const ratioA = Math.min(0.95, Math.max(0.05, rawRatioA));
 
   const poolX = x - 60;
   const poolY = y - 25;
   const poolW = 120;
+  const poolH = 50;
+  const padding = 2;
+  const innerW = poolW - padding * 2;
+  const innerH = poolH - padding * 2;
+
+  const leftWidth = innerW * ratioA;
+  const rightWidth = innerW * (1 - ratioA);
+  const dividerX = poolX + padding + leftWidth;
 
   const borderColor = chain === "l1"
     ? (active ? "rgba(99,102,241,0.6)" : "rgba(99,102,241,0.25)")
     : (active ? "rgba(52,211,153,0.6)" : "rgba(52,211,153,0.25)");
 
-  // Wave path for the liquid surface
-  const waveY = poolY + 2 + liquidBHeight;
+  const tokenALabel = chain === "l1" ? "WETH" : "wWETH";
+  const tokenBLabel = chain === "l1" ? "USDC" : "wUSDC";
+
+  // Visibility thresholds — hide labels on very narrow sides
+  const showLeftLabel = leftWidth >= 25;
+  const showRightLabel = rightWidth >= 25;
+
+  // Surface wave Y for each side (top of fill)
+  const surfaceY = poolY + padding + 4;
 
   return (
     <g>
@@ -384,33 +550,44 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
         x={poolX}
         y={poolY}
         width={poolW}
-        height={50}
+        height={poolH}
         rx={6}
         fill="rgba(18,18,28,0.6)"
         stroke={borderColor}
         strokeWidth={active ? 1.4 : 0.8}
       />
 
-      {/* Token B fill — top portion (gradient) */}
+      {/* Left side — Token A fill (full height, width = leftWidth) */}
       <rect
-        x={poolX + 2}
-        y={poolY + 2}
-        width={poolW - 4}
-        height={liquidBHeight}
-        rx={4}
-        fill="url(#liquidB)"
-        opacity={0.2}
+        x={poolX + padding}
+        y={poolY + padding}
+        width={leftWidth}
+        height={innerH}
+        rx={3}
+        fill="url(#liquidA)"
+        opacity={0.32}
       />
 
-      {/* Token A fill — bottom portion (gradient) */}
+      {/* Right side — Token B fill (full height, width = rightWidth) */}
       <rect
-        x={poolX + 2}
-        y={poolY + 2 + liquidBHeight}
-        width={poolW - 4}
-        height={liquidAHeight}
-        rx={4}
-        fill="url(#liquidA)"
-        opacity={0.25}
+        x={dividerX}
+        y={poolY + padding}
+        width={rightWidth}
+        height={innerH}
+        rx={3}
+        fill="url(#liquidB)"
+        opacity={0.32}
+      />
+
+      {/* Vertical divider line at the boundary */}
+      <line
+        x1={dividerX}
+        y1={poolY + padding}
+        x2={dividerX}
+        y2={poolY + poolH - padding}
+        stroke={chain === "l1" ? "rgba(129,140,248,0.7)" : "rgba(52,211,153,0.7)"}
+        strokeWidth={1}
+        opacity={0.8}
       />
 
       {/* Glass reflection — subtle white gradient at top */}
@@ -421,84 +598,134 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
         height={4}
         rx={2}
         fill="white"
-        opacity={0.06}
+        opacity={0.07}
       />
 
-      {/* Animated wave surface at the A/B boundary */}
-      <g opacity={0.5}>
-        <path
-          d={`M${poolX + 2},${waveY} q15,-3 30,0 t30,0 t30,0 t30,0`}
-          fill="none"
-          stroke="#818cf8"
-          strokeWidth={0.8}
-          opacity={0.6}
-        >
-          <animateTransform
-            attributeName="transform"
-            type="translate"
-            values="0,0; -15,0; 0,0"
-            dur="3s"
-            repeatCount="indefinite"
-          />
-        </path>
-        <path
-          d={`M${poolX + 2},${waveY + 1} q12,2 24,0 t24,0 t24,0 t24,0 t24,0`}
-          fill="none"
-          stroke="#34d399"
-          strokeWidth={0.5}
-          opacity={0.4}
-        >
-          <animateTransform
-            attributeName="transform"
-            type="translate"
-            values="0,0; -10,0; 0,0"
-            dur="4.5s"
-            repeatCount="indefinite"
-          />
-        </path>
-      </g>
+      {/* Horizontal wave on top of LEFT side surface */}
+      {leftWidth > 12 && (() => {
+        const segCount = Math.max(1, Math.floor((leftWidth - 4) / 8));
+        const wavePath = `M${poolX + padding + 2},${surfaceY} q4,-1.5 8,0` +
+          " t8,0".repeat(Math.max(0, segCount - 1));
+        return (
+          <path
+            d={wavePath}
+            fill="none"
+            stroke="#a5b4fc"
+            strokeWidth={0.7}
+            opacity={0.6}
+          >
+            <animateTransform
+              attributeName="transform"
+              type="translate"
+              values="0,0; -8,0; 0,0"
+              dur="3s"
+              repeatCount="indefinite"
+            />
+          </path>
+        );
+      })()}
 
-      {/* Reserve labels */}
-      {reserveA !== null && (
-        <text
-          x={poolX + 8}
-          y={y + 18}
-          fill="#818cf8"
-          fontSize={7}
-          fontFamily="var(--mono)"
-          opacity={0.7}
-        >
-          {chain === "l1" ? "WETH" : "wWETH"}: {formatReserve(reserveA)}
-        </text>
+      {/* Horizontal wave on top of RIGHT side surface */}
+      {rightWidth > 12 && (() => {
+        const segCount = Math.max(1, Math.floor((rightWidth - 4) / 8));
+        const wavePath = `M${dividerX + 2},${surfaceY} q4,-1.5 8,0` +
+          " t8,0".repeat(Math.max(0, segCount - 1));
+        return (
+          <path
+            d={wavePath}
+            fill="none"
+            stroke="#6ee7b7"
+            strokeWidth={0.7}
+            opacity={0.6}
+          >
+            <animateTransform
+              attributeName="transform"
+              type="translate"
+              values="0,0; -8,0; 0,0"
+              dur="3.6s"
+              repeatCount="indefinite"
+            />
+          </path>
+        );
+      })()}
+
+      {/* Left token label + amount (centered in left half) */}
+      {showLeftLabel && (
+        <>
+          <text
+            x={poolX + padding + leftWidth / 2}
+            y={poolY + 22}
+            textAnchor="middle"
+            fill="#c7d2fe"
+            fontSize={8}
+            fontWeight={700}
+            fontFamily="var(--mono)"
+            opacity={0.95}
+          >
+            {tokenALabel}
+          </text>
+          {reserveA !== null && (
+            <text
+              x={poolX + padding + leftWidth / 2}
+              y={poolY + 35}
+              textAnchor="middle"
+              fill="#a5b4fc"
+              fontSize={7}
+              fontFamily="var(--mono)"
+              opacity={0.75}
+            >
+              {formatReserve(reserveA)}
+            </text>
+          )}
+        </>
       )}
-      {reserveB !== null && (
-        <text
-          x={x + 8}
-          y={y + 18}
-          fill="#34d399"
-          fontSize={7}
-          fontFamily="var(--mono)"
-          opacity={0.7}
-        >
-          {chain === "l1" ? "USDC" : "wUSDC"}: {formatReserve(reserveB)}
-        </text>
+
+      {/* Right token label + amount (centered in right half) */}
+      {showRightLabel && (
+        <>
+          <text
+            x={dividerX + rightWidth / 2}
+            y={poolY + 22}
+            textAnchor="middle"
+            fill="#a7f3d0"
+            fontSize={8}
+            fontWeight={700}
+            fontFamily="var(--mono)"
+            opacity={0.95}
+          >
+            {tokenBLabel}
+          </text>
+          {reserveB !== null && (
+            <text
+              x={dividerX + rightWidth / 2}
+              y={poolY + 35}
+              textAnchor="middle"
+              fill="#6ee7b7"
+              fontSize={7}
+              fontFamily="var(--mono)"
+              opacity={0.75}
+            >
+              {formatReserve(reserveB)}
+            </text>
+          )}
+        </>
       )}
 
       {/* Shimmer overlay when active */}
       {active && (
         <rect
-          x={poolX + 2}
-          y={poolY + 2}
-          width={poolW - 4}
-          height={46}
+          x={poolX + padding}
+          y={poolY + padding}
+          width={innerW}
+          height={innerH}
           rx={4}
           fill="none"
-          stroke={chain === "l1" ? "rgba(99,102,241,0.3)" : "rgba(52,211,153,0.3)"}
-          strokeWidth={0.5}
+          stroke={chain === "l1" ? "rgba(99,102,241,0.4)" : "rgba(52,211,153,0.4)"}
+          strokeWidth={0.6}
         >
           <animate
             attributeName="opacity"
-            values="0.3;0.7;0.3"
+            values="0.3;0.8;0.3"
             dur="2s"
             repeatCount="indefinite"
           />
@@ -818,92 +1045,10 @@ export function CrossChainFlowViz({
 
         {/* ══════════════ Layer 5: Particles ══════════════ */}
 
-        {/* Pre-split: User -> Aggregator (large gold particles) */}
-        <ParticleStream
-          pathData={PATHS.userToAgg}
-          color={COL.gold}
-          active={vizPhase >= 1 && !isComplete}
-          speed={0.6}
-          count={3}
-          particleSize="large"
-        />
-
-        {/* Post-split LOCAL: Aggregator -> L1 AMM (smaller gold, proportional) */}
-        <ParticleStream
-          pathData={PATHS.aggToL1Amm}
-          color={COL.gold}
-          active={vizPhase >= 2 && !isComplete}
-          speed={0.8}
-          count={Math.max(2, Math.round(splitPercent / 25))}
-          particleSize="small"
-        />
-
-        {/* Post-split REMOTE: Aggregator -> Portal (smaller gold) */}
-        <ParticleStream
-          pathData={PATHS.aggToPortalDown}
-          color={COL.gold}
-          active={vizPhase >= 3 && !isComplete}
-          speed={0.7}
-          count={Math.max(2, Math.round((100 - splitPercent) / 25))}
-          particleSize="small"
-        />
-        {/* Portal crossing particles -- cyan during bridge (small) */}
-        <ParticleStream
-          pathData={PATHS.portalToL2Exec}
-          color={portalDownActive ? COL.cyan : COL.gold}
-          active={vizPhase >= 3 && !isComplete}
-          speed={0.9}
-          count={4}
-          particleSize="small"
-        />
-
-        {/* L1 output: L1 AMM -> Output (small blue) */}
-        <ParticleStream
-          pathData={PATHS.l1AmmToOutput}
-          color={COL.blue}
-          active={vizPhase >= 4 && !isComplete}
-          speed={0.8}
-          count={3}
-          particleSize="small"
-        />
-
-        {/* Phase 5: L2 Executor -> L2 AMM (color transition, small) */}
-        <ParticleStream
-          pathData={PATHS.l2ExecToL2Amm}
-          color={COL.gold}
-          active={vizPhase >= 5 && !isComplete}
-          speed={0.8}
-          count={3}
-          particleSize="small"
-        />
-        {/* Overlaid blue particles for transition effect */}
-        <ParticleStream
-          pathData={PATHS.l2ExecToL2Amm}
-          color={COL.blue}
-          active={vizPhase >= 5 && !isComplete}
-          speed={1.1}
-          count={2}
-          particleSize="small"
-        />
-
-        {/* L2 output: L2 AMM -> Portal (up) (small blue) */}
-        <ParticleStream
-          pathData={PATHS.l2AmmToPortalUp}
-          color={portalUpActive ? COL.cyan : COL.blue}
-          active={vizPhase >= 6 && !isComplete}
-          speed={1.0}
-          count={4}
-          particleSize="small"
-        />
-        {/* L2 output: Portal -> Output (small blue) */}
-        <ParticleStream
-          pathData={PATHS.portalToOutput}
-          color={COL.blue}
-          active={vizPhase >= 6 && !isComplete}
-          speed={0.7}
-          count={3}
-          particleSize="small"
-        />
+        {/* Coordinated journey — single particle splits at Aggregator into local
+            and remote branches. Both branches arrive at Output simultaneously.
+            Loops forever, independent of vizPhase. */}
+        <CoordinatedJourney />
 
         {/* Merge pulse at Output node when both streams converge */}
         {vizPhase >= 6 && !isComplete && (

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -211,8 +211,10 @@ interface JourneyParticleProps {
   labelDy?: number;
 }
 
-// Cycle period in seconds — ALL particles loop in lock-step at this interval
-const CYCLE_PERIOD = 10;
+// Cycle period in seconds — ALL particles loop in lock-step at this interval.
+// The journey runs from t=0 to t=10, then there's a 2s pause before the next
+// cycle starts at t=12.
+const CYCLE_PERIOD = 12;
 
 // Build a 5-cycle list of begin times so SMIL re-fires reliably even when
 // the browser throttles the cycleClock animation. Indefinite repetition is
@@ -512,6 +514,9 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
   // invariant). So the visual split is always 50/50 — the actual reserve
   // amounts are shown as labels inside each half. Liquidity is conveyed
   // through the labels, not the bar widths.
+  //
+  // Liquid fills 70% of the inner height from the bottom — the top 30% is
+  // empty headroom, like a real glass container with liquid inside.
   const poolX = x - 60;
   const poolY = y - 25;
   const poolW = 120;
@@ -525,6 +530,12 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
   const rightWidth = halfW;
   const dividerX = poolX + padding + halfW;
 
+  // Liquid level: 70% fill from the bottom of the inner area
+  const fillRatio = 0.7;
+  const liquidH = innerH * fillRatio;
+  const liquidTop = poolY + padding + (innerH - liquidH);
+  const liquidBottom = poolY + padding + innerH;
+
   const borderColor = chain === "l1"
     ? (active ? "rgba(99,102,241,0.6)" : "rgba(99,102,241,0.25)")
     : (active ? "rgba(52,211,153,0.6)" : "rgba(52,211,153,0.25)");
@@ -536,8 +547,8 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
   const showLeftLabel = leftWidth >= 25;
   const showRightLabel = rightWidth >= 25;
 
-  // Surface wave Y for each side (top of fill)
-  const surfaceY = poolY + padding + 4;
+  // Surface wave Y — sits at the top of the liquid (not the top of the container)
+  const surfaceY = liquidTop;
 
   return (
     <g>
@@ -553,34 +564,34 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
         strokeWidth={active ? 1.4 : 0.8}
       />
 
-      {/* Left side — Token A fill (full height, width = leftWidth) */}
+      {/* Left side — Token A liquid fill (70% from bottom) */}
       <rect
         x={poolX + padding}
-        y={poolY + padding}
+        y={liquidTop}
         width={leftWidth}
-        height={innerH}
+        height={liquidH}
         rx={3}
         fill="url(#liquidA)"
-        opacity={0.32}
+        opacity={0.38}
       />
 
-      {/* Right side — Token B fill (full height, width = rightWidth) */}
+      {/* Right side — Token B liquid fill (70% from bottom) */}
       <rect
         x={dividerX}
-        y={poolY + padding}
+        y={liquidTop}
         width={rightWidth}
-        height={innerH}
+        height={liquidH}
         rx={3}
         fill="url(#liquidB)"
-        opacity={0.32}
+        opacity={0.38}
       />
 
-      {/* Vertical divider line at the boundary */}
+      {/* Vertical divider line — only spans the liquid portion */}
       <line
         x1={dividerX}
-        y1={poolY + padding}
+        y1={liquidTop}
         x2={dividerX}
-        y2={poolY + poolH - padding}
+        y2={liquidBottom}
         stroke={chain === "l1" ? "rgba(129,140,248,0.7)" : "rgba(52,211,153,0.7)"}
         strokeWidth={1}
         opacity={0.8}
@@ -645,12 +656,12 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
         );
       })()}
 
-      {/* Left token label + amount (centered in left half) */}
+      {/* Left token label + amount (centered in left half, inside the liquid) */}
       {showLeftLabel && (
         <>
           <text
             x={poolX + padding + leftWidth / 2}
-            y={poolY + 22}
+            y={liquidTop + liquidH / 2 - 1}
             textAnchor="middle"
             fill="#c7d2fe"
             fontSize={8}
@@ -663,7 +674,7 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
           {reserveA !== null && (
             <text
               x={poolX + padding + leftWidth / 2}
-              y={poolY + 35}
+              y={liquidTop + liquidH / 2 + 9}
               textAnchor="middle"
               fill="#a5b4fc"
               fontSize={7}
@@ -676,12 +687,12 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
         </>
       )}
 
-      {/* Right token label + amount (centered in right half) */}
+      {/* Right token label + amount (centered in right half, inside the liquid) */}
       {showRightLabel && (
         <>
           <text
             x={dividerX + rightWidth / 2}
-            y={poolY + 22}
+            y={liquidTop + liquidH / 2 - 1}
             textAnchor="middle"
             fill="#a7f3d0"
             fontSize={8}
@@ -694,7 +705,7 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
           {reserveB !== null && (
             <text
               x={dividerX + rightWidth / 2}
-              y={poolY + 35}
+              y={liquidTop + liquidH / 2 + 9}
               textAnchor="middle"
               fill="#6ee7b7"
               fontSize={7}
@@ -1039,12 +1050,7 @@ export function CrossChainFlowViz({
         <Portal x={300} y={190} active={portalDownActive} />
         <Portal x={790} y={190} active={portalUpActive} />
 
-        {/* ══════════════ Layer 5: Particles ══════════════ */}
-
-        {/* Coordinated journey — single particle splits at Aggregator into local
-            and remote branches. Both branches arrive at Output simultaneously.
-            Loops forever, independent of vizPhase. */}
-        <CoordinatedJourney />
+        {/* ══════════════ Layer 5: Particles (background ambient only) ══════════════ */}
 
         {/* Merge pulse at Output node when both streams converge */}
         {vizPhase >= 6 && !isComplete && (
@@ -1405,6 +1411,11 @@ export function CrossChainFlowViz({
             opacity={0.15}
           />
         ))}
+
+        {/* ══════════════ Layer 8: Coordinated journey (TOPMOST) ══════════════
+            Particles + labels render LAST so they always paint on top of nodes,
+            pools, and pool labels. */}
+        <CoordinatedJourney />
       </svg>
     </div>
   );

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -535,7 +535,6 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }
   const ratio = Math.max(0.12, Math.min(0.92, fillRatio));
   const liquidH = innerH * ratio;
   const liquidTop = poolY + padding + (innerH - liquidH);
-  const liquidBottom = poolY + padding + innerH;
 
   const borderColor = chain === "l1"
     ? (active ? "rgba(99,102,241,0.6)" : "rgba(99,102,241,0.25)")
@@ -590,12 +589,12 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }
         opacity={0.38}
       />
 
-      {/* Vertical divider line — only spans the liquid portion */}
+      {/* Vertical divider line — spans the FULL container height (top to bottom) */}
       <line
         x1={dividerX}
-        y1={liquidTop}
+        y1={poolY + padding}
         x2={dividerX}
-        y2={liquidBottom}
+        y2={poolY + poolH - padding}
         stroke={chain === "l1" ? "rgba(129,140,248,0.7)" : "rgba(52,211,153,0.7)"}
         strokeWidth={1}
         opacity={0.8}

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -211,6 +211,16 @@ interface JourneyParticleProps {
   labelDy?: number;
 }
 
+// Cycle period in seconds — ALL particles loop in lock-step at this interval
+const CYCLE_PERIOD = 5;
+
+// Build a 5-cycle list of begin times so SMIL re-fires reliably even when
+// the browser throttles the cycleClock animation. Indefinite repetition is
+// then driven by the explicit list, not by referencing a single sync source.
+function buildBeginTimes(offset: number, count = 50): string {
+  return Array.from({ length: count }, (_, i) => `${offset + i * CYCLE_PERIOD}s`).join(";");
+}
+
 function JourneyParticle({
   path,
   duration,
@@ -222,50 +232,50 @@ function JourneyParticle({
   labelDy = -12,
 }: JourneyParticleProps) {
   const sz = PARTICLE_SIZES[size];
-  // Animations are tied to the master cycle (#cycleClock). Each cycle the particle
-  // spawns at its beginOffset, animates for `duration`, then disappears.
-  const startEvent = `cycleClock.begin+${beginOffset}s`;
-  const endEvent = `cycleClock.begin+${beginOffset + duration}s`;
+  // Each segment fires at offset, offset+CYCLE, offset+2*CYCLE, ... for many cycles.
+  // No reliance on cycleClock — direct begin times survive tab throttling.
+  const beginList = buildBeginTimes(beginOffset);
+  const endList = buildBeginTimes(beginOffset + duration);
   const dur = `${duration}s`;
 
   return (
     <g opacity={0}>
       {/* Master visibility — show during the segment, hide at the end */}
-      <set attributeName="opacity" to="1" begin={startEvent} />
-      <set attributeName="opacity" to="0" begin={endEvent} />
+      <set attributeName="opacity" to="1" begin={beginList} />
+      <set attributeName="opacity" to="0" begin={endList} />
 
       {/* Plasma tail */}
       <circle r={sz.plasma} fill={color} opacity={0.18} filter="url(#plasma)">
-        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+        <animateMotion dur={dur} begin={beginList} path={path} fill="freeze" />
       </circle>
       {/* Color halo */}
       <circle r={sz.halo} fill={color} opacity={0.45} filter="url(#glow)">
-        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+        <animateMotion dur={dur} begin={beginList} path={path} fill="freeze" />
       </circle>
       {/* White core */}
       <circle r={sz.core} fill={COL.white} opacity={0.95}>
-        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+        <animateMotion dur={dur} begin={beginList} path={path} fill="freeze" />
       </circle>
 
-      {/* Label — follows the particle on the same path with the same timing.
-          The text uses y={labelDy} so it sits offset above/below the moving origin.
-          NOTE: no `filter` on text — glow blurs glyphs and ruins legibility. */}
+      {/* Label — follows the particle. Thin & elegant: no filter, light weight,
+          subtle dark stroke for contrast on any background. */}
       <text
         x={0}
         y={labelDy}
-        fontSize={12}
-        fontWeight={800}
+        fontSize={10}
+        fontWeight={500}
         fill={labelColor}
         textAnchor="middle"
         fontFamily="var(--sans)"
+        letterSpacing="0.03em"
         style={{ paintOrder: "stroke fill" }}
-        stroke="#000"
-        strokeWidth={3}
+        stroke="#0b0d18"
+        strokeWidth={2.2}
         strokeLinejoin="round"
-        strokeOpacity={0.9}
+        strokeOpacity={0.85}
       >
         {label}
-        <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
+        <animateMotion dur={dur} begin={beginList} path={path} fill="freeze" />
       </text>
     </g>
   );
@@ -303,26 +313,19 @@ const JOURNEY_PATHS = {
  * into local and remote branches that arrive at Output simultaneously. Loops forever.
  */
 function CoordinatedJourney() {
+  // 5-second cycle (CYCLE_PERIOD). Layout:
+  //   t=0   → 1.2  Pre-split: User → Aggregator
+  //   t=1.2 → 5.0  Local:  Agg → L1 AMM (1.9s WETH) → Output (1.9s USDC)
+  //   t=1.2 → 5.0  Remote: Agg → Portal Down → L2 Exec → L2 AMM → Portal Up → Output
+  //
+  // No master cycleClock — each segment has its own explicit list of begin times
+  // (built by buildBeginTimes), so the loop survives browser tab throttling.
   return (
     <g>
-      {/* Master cycle clock — drives the begin events of every segment.
-          An 8s repeating animation; each cycleClock.begin event restarts the chain. */}
-      <rect x={-10} y={-10} width={1} height={1} fill="none" opacity={0}>
-        <animate
-          id="cycleClock"
-          attributeName="opacity"
-          from="0"
-          to="0"
-          dur="8s"
-          begin="0s"
-          repeatCount="indefinite"
-        />
-      </rect>
-
-      {/* ── Phase A: Pre-split (t=0 → t=2) ── */}
+      {/* ── Phase A: Pre-split (t=0 → 1.2) ── */}
       <JourneyParticle
         path={JOURNEY_PATHS.preSplit}
-        duration={2.0}
+        duration={1.2}
         beginOffset={0}
         color={COL.gold}
         label="WETH"
@@ -331,11 +334,11 @@ function CoordinatedJourney() {
         labelDy={-15}
       />
 
-      {/* ── Phase B Local: Aggregator → L1 AMM → Output (t=2 → t=8) ── */}
+      {/* ── Phase B Local: Agg → L1 AMM → Output (t=1.2 → 5.0) ── */}
       <JourneyParticle
         path={JOURNEY_PATHS.localToL1Amm}
-        duration={3.0}
-        beginOffset={2.0}
+        duration={1.9}
+        beginOffset={1.2}
         color={COL.gold}
         label="WETH"
         labelColor={COL.gold}
@@ -343,21 +346,20 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.localToOutput}
-        duration={3.0}
-        beginOffset={5.0}
+        duration={1.9}
+        beginOffset={3.1}
         color={COL.blue}
         label="USDC"
         labelColor={COL.blue}
         labelDy={-14}
       />
 
-      {/* ── Phase B Remote: Aggregator → Portal → L2 Exec → L2 AMM → Portal → Output (t=2 → t=8) ──
-          Five segments totaling 6s — same total wall-clock time as the local branch
-          even though the path is much longer. The remote particle moves visually faster. */}
+      {/* ── Phase B Remote: Agg → Portal → L2 Exec → L2 AMM → Portal → Output ──
+          5 segments totaling 3.8s, same wall-clock as local branch. */}
       <JourneyParticle
         path={JOURNEY_PATHS.remoteAggToPortalDown}
-        duration={1.0}
-        beginOffset={2.0}
+        duration={0.65}
+        beginOffset={1.2}
         color={COL.gold}
         label="WETH"
         labelColor={COL.gold}
@@ -365,8 +367,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remotePortalToL2Exec}
-        duration={1.0}
-        beginOffset={3.0}
+        duration={0.65}
+        beginOffset={1.85}
         color={COL.cyan}
         label="wWETH"
         labelColor={COL.cyan}
@@ -374,8 +376,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remoteL2ExecToL2Amm}
-        duration={1.2}
-        beginOffset={4.0}
+        duration={0.8}
+        beginOffset={2.5}
         color={COL.cyan}
         label="wWETH"
         labelColor={COL.cyan}
@@ -383,8 +385,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remoteL2AmmToPortalUp}
-        duration={1.4}
-        beginOffset={5.2}
+        duration={0.85}
+        beginOffset={3.3}
         color={COL.cyan}
         label="wUSDC"
         labelColor={COL.cyan}
@@ -392,8 +394,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remotePortalToOutput}
-        duration={1.4}
-        beginOffset={6.6}
+        duration={0.85}
+        beginOffset={4.15}
         color={COL.blue}
         label="USDC"
         labelColor={COL.blue}

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -507,22 +507,19 @@ interface LiquidPoolProps {
   reserveB: string | null;
   chain: "l1" | "l2";
   active: boolean;
-  /** Visual scale 0.55–1.0; bigger = more total liquidity vs the other pool */
-  scale?: number;
+  /** Liquid fill 0.15–0.85; how full the container is (bigger = more TVL) */
+  fillRatio?: number;
 }
 
-function LiquidPool({ x, y, reserveA, reserveB, chain, active, scale = 1 }: LiquidPoolProps) {
+function LiquidPool({ x, y, reserveA, reserveB, chain, active, fillRatio = 0.7 }: LiquidPoolProps) {
   // In a Uniswap V2 AMM, both sides always have equal VALUE (that's the
-  // invariant). So the visual split is always 50/50 — the actual reserve
-  // amounts are shown as labels inside each half. Liquidity is conveyed
-  // through the labels and the OVERALL pool size (bigger pool = more TVL).
+  // invariant). So the visual split is always 50/50.
   //
-  // Liquid fills 70% of the inner height from the bottom — the top 30% is
-  // empty headroom, like a real glass container with liquid inside.
-  const baseW = 120;
-  const baseH = 50;
-  const poolW = Math.round(baseW * scale);
-  const poolH = Math.round(baseH * scale);
+  // BOTH pool containers have the SAME size. What changes is how full each
+  // container is — the LIQUID LEVEL reflects the relative liquidity. A pool
+  // with 2x more TVL than another will be visibly more full.
+  const poolW = 120;
+  const poolH = 50;
   const poolX = x - poolW / 2;
   const poolY = y - poolH / 2;
   const padding = 2;
@@ -534,9 +531,9 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active, scale = 1 }: Liqu
   const rightWidth = halfW;
   const dividerX = poolX + padding + halfW;
 
-  // Liquid level: 70% fill from the bottom of the inner area
-  const fillRatio = 0.7;
-  const liquidH = innerH * fillRatio;
+  // Liquid level — how full this pool is (clamped to keep something visible)
+  const ratio = Math.max(0.12, Math.min(0.92, fillRatio));
+  const liquidH = innerH * ratio;
   const liquidTop = poolY + padding + (innerH - liquidH);
   const liquidBottom = poolY + padding + innerH;
 
@@ -885,15 +882,16 @@ export function CrossChainFlowViz({
   const localWidth = (splitPercent / 100) * 3 + 0.5;
   const remoteWidth = ((100 - splitPercent) / 100) * 3 + 0.5;
 
-  // Pool sizes scale with relative liquidity. Bigger pool = full size (1.0),
-  // smaller pool = sqrt of the ratio so the difference is visible but not extreme.
+  // Both pool containers are the SAME size. The LIQUID LEVEL inside differs
+  // proportionally to relative liquidity — bigger TVL = more full container.
   const l1Liq = l1ReserveA ? parseFloat(l1ReserveA) : 0;
   const l2Liq = l2ReserveA ? parseFloat(l2ReserveA) : 0;
   const maxLiq = Math.max(l1Liq, l2Liq, 1);
-  // Use sqrt to soften the visual difference (a 2x liquidity ratio → ~1.41x size).
-  // Floor at 0.55 so even tiny pools stay readable.
-  const l1Scale = Math.max(0.55, Math.sqrt(l1Liq / maxLiq) || 0.55);
-  const l2Scale = Math.max(0.55, Math.sqrt(l2Liq / maxLiq) || 0.55);
+  // The pool with the most liquidity fills to ~85% of the container.
+  // Smaller pool fills proportionally (linear ratio).
+  const MAX_FILL = 0.85;
+  const l1Fill = (l1Liq / maxLiq) * MAX_FILL;
+  const l2Fill = (l2Liq / maxLiq) * MAX_FILL;
 
   // Determine which nodes are active based on phase
   const activeNodes = useMemo(() => {
@@ -1074,7 +1072,7 @@ export function CrossChainFlowViz({
           reserveB={l1ReserveB}
           chain="l1"
           active={vizPhase >= 2 && vizPhase <= 4}
-          scale={l1Scale}
+          fillRatio={l1Fill}
         />
         <LiquidPool
           x={600}
@@ -1083,7 +1081,7 @@ export function CrossChainFlowViz({
           reserveB={l2ReserveB}
           chain="l2"
           active={vizPhase >= 5 && vizPhase <= 6}
-          scale={l2Scale}
+          fillRatio={l2Fill}
         />
 
         {/* ══════════════ Layer 4: Bridge Portals ══════════════ */}

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -248,20 +248,21 @@ function JourneyParticle({
       </circle>
 
       {/* Label — follows the particle on the same path with the same timing.
-          The text uses y={labelDy} so it sits offset above/below the moving origin. */}
+          The text uses y={labelDy} so it sits offset above/below the moving origin.
+          NOTE: no `filter` on text — glow blurs glyphs and ruins legibility. */}
       <text
         x={0}
         y={labelDy}
-        fontSize={9}
-        fontWeight={700}
+        fontSize={12}
+        fontWeight={800}
         fill={labelColor}
         textAnchor="middle"
-        fontFamily="var(--mono)"
-        filter="url(#glow)"
+        fontFamily="var(--sans)"
         style={{ paintOrder: "stroke fill" }}
-        stroke="rgba(8,10,18,0.75)"
-        strokeWidth={2.4}
+        stroke="#000"
+        strokeWidth={3}
         strokeLinejoin="round"
+        strokeOpacity={0.9}
       >
         {label}
         <animateMotion dur={dur} begin={startEvent} path={path} fill="freeze" />
@@ -305,99 +306,98 @@ function CoordinatedJourney() {
   return (
     <g>
       {/* Master cycle clock — drives the begin events of every segment.
-          A 4s repeating animation; each cycleClock.begin event restarts the chain. */}
+          An 8s repeating animation; each cycleClock.begin event restarts the chain. */}
       <rect x={-10} y={-10} width={1} height={1} fill="none" opacity={0}>
         <animate
           id="cycleClock"
           attributeName="opacity"
           from="0"
           to="0"
-          dur="4s"
+          dur="8s"
           begin="0s"
           repeatCount="indefinite"
         />
       </rect>
 
-      {/* ── Phase A: Pre-split (t=0 → t=1) ── */}
+      {/* ── Phase A: Pre-split (t=0 → t=2) ── */}
       <JourneyParticle
         path={JOURNEY_PATHS.preSplit}
-        duration={1.0}
+        duration={2.0}
         beginOffset={0}
         color={COL.gold}
         label="WETH"
         labelColor={COL.gold}
         size="large"
-        labelDy={-13}
+        labelDy={-15}
       />
 
-      {/* ── Phase B Local: Aggregator → L1 AMM → Output (t=1 → t=4) ──
-          Two segments: WETH (1s) then USDC (2s). */}
+      {/* ── Phase B Local: Aggregator → L1 AMM → Output (t=2 → t=8) ── */}
       <JourneyParticle
         path={JOURNEY_PATHS.localToL1Amm}
-        duration={1.5}
-        beginOffset={1.0}
+        duration={3.0}
+        beginOffset={2.0}
         color={COL.gold}
         label="WETH"
         labelColor={COL.gold}
-        labelDy={-12}
+        labelDy={-14}
       />
       <JourneyParticle
         path={JOURNEY_PATHS.localToOutput}
-        duration={1.5}
-        beginOffset={2.5}
+        duration={3.0}
+        beginOffset={5.0}
+        color={COL.blue}
+        label="USDC"
+        labelColor={COL.blue}
+        labelDy={-14}
+      />
+
+      {/* ── Phase B Remote: Aggregator → Portal → L2 Exec → L2 AMM → Portal → Output (t=2 → t=8) ──
+          Five segments totaling 6s — same total wall-clock time as the local branch
+          even though the path is much longer. The remote particle moves visually faster. */}
+      <JourneyParticle
+        path={JOURNEY_PATHS.remoteAggToPortalDown}
+        duration={1.0}
+        beginOffset={2.0}
+        color={COL.gold}
+        label="WETH"
+        labelColor={COL.gold}
+        labelDy={-12}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remotePortalToL2Exec}
+        duration={1.0}
+        beginOffset={3.0}
+        color={COL.cyan}
+        label="wWETH"
+        labelColor={COL.cyan}
+        labelDy={-12}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remoteL2ExecToL2Amm}
+        duration={1.2}
+        beginOffset={4.0}
+        color={COL.cyan}
+        label="wWETH"
+        labelColor={COL.cyan}
+        labelDy={16}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remoteL2AmmToPortalUp}
+        duration={1.4}
+        beginOffset={5.2}
+        color={COL.cyan}
+        label="wUSDC"
+        labelColor={COL.cyan}
+        labelDy={-12}
+      />
+      <JourneyParticle
+        path={JOURNEY_PATHS.remotePortalToOutput}
+        duration={1.4}
+        beginOffset={6.6}
         color={COL.blue}
         label="USDC"
         labelColor={COL.blue}
         labelDy={-12}
-      />
-
-      {/* ── Phase B Remote: Aggregator → Portal → L2 Exec → L2 AMM → Portal → Output (t=1 → t=4) ──
-          Five segments totaling 3s — same total wall-clock time as the local branch
-          even though the path is much longer. The remote particle moves visually faster. */}
-      <JourneyParticle
-        path={JOURNEY_PATHS.remoteAggToPortalDown}
-        duration={0.5}
-        beginOffset={1.0}
-        color={COL.gold}
-        label="WETH"
-        labelColor={COL.gold}
-        labelDy={-10}
-      />
-      <JourneyParticle
-        path={JOURNEY_PATHS.remotePortalToL2Exec}
-        duration={0.5}
-        beginOffset={1.5}
-        color={COL.cyan}
-        label="wWETH"
-        labelColor={COL.cyan}
-        labelDy={-10}
-      />
-      <JourneyParticle
-        path={JOURNEY_PATHS.remoteL2ExecToL2Amm}
-        duration={0.6}
-        beginOffset={2.0}
-        color={COL.cyan}
-        label="wWETH"
-        labelColor={COL.cyan}
-        labelDy={14}
-      />
-      <JourneyParticle
-        path={JOURNEY_PATHS.remoteL2AmmToPortalUp}
-        duration={0.7}
-        beginOffset={2.6}
-        color={COL.cyan}
-        label="wUSDC"
-        labelColor={COL.cyan}
-        labelDy={-10}
-      />
-      <JourneyParticle
-        path={JOURNEY_PATHS.remotePortalToOutput}
-        duration={0.7}
-        beginOffset={3.3}
-        color={COL.blue}
-        label="USDC"
-        labelColor={COL.blue}
-        labelDy={-10}
       />
     </g>
   );

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -212,7 +212,7 @@ interface JourneyParticleProps {
 }
 
 // Cycle period in seconds — ALL particles loop in lock-step at this interval
-const CYCLE_PERIOD = 5;
+const CYCLE_PERIOD = 10;
 
 // Build a 5-cycle list of begin times so SMIL re-fires reliably even when
 // the browser throttles the cycleClock animation. Indefinite repetition is
@@ -257,22 +257,19 @@ function JourneyParticle({
         <animateMotion dur={dur} begin={beginList} path={path} fill="freeze" />
       </circle>
 
-      {/* Label — follows the particle. Thin & elegant: no filter, light weight,
-          subtle dark stroke for contrast on any background. */}
+      {/* Label — follows the particle. Thin & elegant: no stroke, no filter.
+          Plain colored text relies on its own brightness against the dark
+          lane backgrounds. */}
       <text
         x={0}
         y={labelDy}
-        fontSize={10}
+        fontSize={9}
         fontWeight={500}
         fill={labelColor}
         textAnchor="middle"
         fontFamily="var(--sans)"
-        letterSpacing="0.03em"
-        style={{ paintOrder: "stroke fill" }}
-        stroke="#0b0d18"
-        strokeWidth={2.2}
-        strokeLinejoin="round"
-        strokeOpacity={0.85}
+        letterSpacing="0.05em"
+        opacity={0.95}
       >
         {label}
         <animateMotion dur={dur} begin={beginList} path={path} fill="freeze" />
@@ -313,19 +310,19 @@ const JOURNEY_PATHS = {
  * into local and remote branches that arrive at Output simultaneously. Loops forever.
  */
 function CoordinatedJourney() {
-  // 5-second cycle (CYCLE_PERIOD). Layout:
-  //   t=0   → 1.2  Pre-split: User → Aggregator
-  //   t=1.2 → 5.0  Local:  Agg → L1 AMM (1.9s WETH) → Output (1.9s USDC)
-  //   t=1.2 → 5.0  Remote: Agg → Portal Down → L2 Exec → L2 AMM → Portal Up → Output
+  // 10-second cycle (CYCLE_PERIOD). Layout:
+  //   t=0   → 2.4   Pre-split: User → Aggregator
+  //   t=2.4 → 10.0  Local:  Agg → L1 AMM (3.8s WETH) → Output (3.8s USDC)
+  //   t=2.4 → 10.0  Remote: Agg → Portal Down → L2 Exec → L2 AMM → Portal Up → Output
   //
   // No master cycleClock — each segment has its own explicit list of begin times
   // (built by buildBeginTimes), so the loop survives browser tab throttling.
   return (
     <g>
-      {/* ── Phase A: Pre-split (t=0 → 1.2) ── */}
+      {/* ── Phase A: Pre-split (t=0 → 2.4) ── */}
       <JourneyParticle
         path={JOURNEY_PATHS.preSplit}
-        duration={1.2}
+        duration={2.4}
         beginOffset={0}
         color={COL.gold}
         label="WETH"
@@ -334,11 +331,11 @@ function CoordinatedJourney() {
         labelDy={-15}
       />
 
-      {/* ── Phase B Local: Agg → L1 AMM → Output (t=1.2 → 5.0) ── */}
+      {/* ── Phase B Local: Agg → L1 AMM → Output (t=2.4 → 10.0) ── */}
       <JourneyParticle
         path={JOURNEY_PATHS.localToL1Amm}
-        duration={1.9}
-        beginOffset={1.2}
+        duration={3.8}
+        beginOffset={2.4}
         color={COL.gold}
         label="WETH"
         labelColor={COL.gold}
@@ -346,8 +343,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.localToOutput}
-        duration={1.9}
-        beginOffset={3.1}
+        duration={3.8}
+        beginOffset={6.2}
         color={COL.blue}
         label="USDC"
         labelColor={COL.blue}
@@ -355,11 +352,11 @@ function CoordinatedJourney() {
       />
 
       {/* ── Phase B Remote: Agg → Portal → L2 Exec → L2 AMM → Portal → Output ──
-          5 segments totaling 3.8s, same wall-clock as local branch. */}
+          5 segments totaling 7.6s, same wall-clock as local branch. */}
       <JourneyParticle
         path={JOURNEY_PATHS.remoteAggToPortalDown}
-        duration={0.65}
-        beginOffset={1.2}
+        duration={1.3}
+        beginOffset={2.4}
         color={COL.gold}
         label="WETH"
         labelColor={COL.gold}
@@ -367,8 +364,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remotePortalToL2Exec}
-        duration={0.65}
-        beginOffset={1.85}
+        duration={1.3}
+        beginOffset={3.7}
         color={COL.cyan}
         label="wWETH"
         labelColor={COL.cyan}
@@ -376,8 +373,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remoteL2ExecToL2Amm}
-        duration={0.8}
-        beginOffset={2.5}
+        duration={1.6}
+        beginOffset={5.0}
         color={COL.cyan}
         label="wWETH"
         labelColor={COL.cyan}
@@ -385,8 +382,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remoteL2AmmToPortalUp}
-        duration={0.85}
-        beginOffset={3.3}
+        duration={1.7}
+        beginOffset={6.6}
         color={COL.cyan}
         label="wUSDC"
         labelColor={COL.cyan}
@@ -394,8 +391,8 @@ function CoordinatedJourney() {
       />
       <JourneyParticle
         path={JOURNEY_PATHS.remotePortalToOutput}
-        duration={0.85}
-        beginOffset={4.15}
+        duration={1.7}
+        beginOffset={8.3}
         color={COL.blue}
         label="USDC"
         labelColor={COL.blue}
@@ -511,14 +508,10 @@ interface LiquidPoolProps {
 }
 
 function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps) {
-  const a = reserveA ? parseFloat(reserveA) : 0;
-  const b = reserveB ? parseFloat(reserveB) : 0;
-  const total = a + b;
-  // Vertical split: left = token A, right = token B. Width proportional to raw token COUNT.
-  // Clamp ratio so neither side disappears entirely (5% min for each).
-  const rawRatioA = total > 0 ? a / total : 0.5;
-  const ratioA = Math.min(0.95, Math.max(0.05, rawRatioA));
-
+  // In a Uniswap V2 AMM, both sides always have equal VALUE (that's the
+  // invariant). So the visual split is always 50/50 — the actual reserve
+  // amounts are shown as labels inside each half. Liquidity is conveyed
+  // through the labels, not the bar widths.
   const poolX = x - 60;
   const poolY = y - 25;
   const poolW = 120;
@@ -527,9 +520,10 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
   const innerW = poolW - padding * 2;
   const innerH = poolH - padding * 2;
 
-  const leftWidth = innerW * ratioA;
-  const rightWidth = innerW * (1 - ratioA);
-  const dividerX = poolX + padding + leftWidth;
+  const halfW = innerW / 2;
+  const leftWidth = halfW;
+  const rightWidth = halfW;
+  const dividerX = poolX + padding + halfW;
 
   const borderColor = chain === "l1"
     ? (active ? "rgba(99,102,241,0.6)" : "rgba(99,102,241,0.25)")

--- a/ui/src/components/CrossChainFlowViz.tsx
+++ b/ui/src/components/CrossChainFlowViz.tsx
@@ -507,20 +507,24 @@ interface LiquidPoolProps {
   reserveB: string | null;
   chain: "l1" | "l2";
   active: boolean;
+  /** Visual scale 0.55–1.0; bigger = more total liquidity vs the other pool */
+  scale?: number;
 }
 
-function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps) {
+function LiquidPool({ x, y, reserveA, reserveB, chain, active, scale = 1 }: LiquidPoolProps) {
   // In a Uniswap V2 AMM, both sides always have equal VALUE (that's the
   // invariant). So the visual split is always 50/50 — the actual reserve
   // amounts are shown as labels inside each half. Liquidity is conveyed
-  // through the labels, not the bar widths.
+  // through the labels and the OVERALL pool size (bigger pool = more TVL).
   //
   // Liquid fills 70% of the inner height from the bottom — the top 30% is
   // empty headroom, like a real glass container with liquid inside.
-  const poolX = x - 60;
-  const poolY = y - 25;
-  const poolW = 120;
-  const poolH = 50;
+  const baseW = 120;
+  const baseH = 50;
+  const poolW = Math.round(baseW * scale);
+  const poolH = Math.round(baseH * scale);
+  const poolX = x - poolW / 2;
+  const poolY = y - poolH / 2;
   const padding = 2;
   const innerW = poolW - padding * 2;
   const innerH = poolH - padding * 2;
@@ -547,8 +551,11 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
   const showLeftLabel = leftWidth >= 25;
   const showRightLabel = rightWidth >= 25;
 
-  // Surface wave Y — sits at the top of the liquid (not the top of the container)
-  const surfaceY = liquidTop;
+  // Surface wave Y — sit slightly INSIDE the liquid so wave crests just touch
+  // the visual top of the liquid rect. The wave path then oscillates around
+  // this Y, so half the wave is above (touching liquidTop) and half below.
+  const waveAmp = 1.5;
+  const surfaceY = liquidTop + waveAmp;
 
   return (
     <g>
@@ -608,51 +615,73 @@ function LiquidPool({ x, y, reserveA, reserveB, chain, active }: LiquidPoolProps
         opacity={0.07}
       />
 
-      {/* Horizontal wave on top of LEFT side surface */}
-      {leftWidth > 12 && (() => {
-        const segCount = Math.max(1, Math.floor((leftWidth - 4) / 8));
-        const wavePath = `M${poolX + padding + 2},${surfaceY} q4,-1.5 8,0` +
-          " t8,0".repeat(Math.max(0, segCount - 1));
-        return (
-          <path
-            d={wavePath}
-            fill="none"
-            stroke="#a5b4fc"
-            strokeWidth={0.7}
-            opacity={0.6}
-          >
-            <animateTransform
-              attributeName="transform"
-              type="translate"
-              values="0,0; -8,0; 0,0"
-              dur="3s"
-              repeatCount="indefinite"
-            />
-          </path>
-        );
-      })()}
+      {/* Build a symmetric sine-like wave path centered on yCenter.
+          Each "cycle" is 12px wide and oscillates ±waveAmp around yCenter,
+          so crests touch (yCenter - waveAmp) and valleys reach (yCenter + waveAmp). */}
+      {(() => {
+        const buildWave = (xStart: number, xEnd: number, yCenter: number) => {
+          const cycleW = 12;
+          const halfCycle = cycleW / 2;
+          let d = `M${xStart},${yCenter}`;
+          // Extend slightly past xEnd so the animateTransform translate doesn't reveal a gap
+          const extEnd = xEnd + cycleW;
+          let x = xStart;
+          let goingUp = true;
+          while (x < extEnd) {
+            const nextX = x + halfCycle;
+            const peakY = goingUp ? yCenter - waveAmp : yCenter + waveAmp;
+            const cx = x + halfCycle / 2;
+            // Quadratic curve: control point at midpoint with peak Y, end point at next baseline
+            d += ` Q${cx},${peakY} ${nextX},${yCenter}`;
+            x = nextX;
+            goingUp = !goingUp;
+          }
+          return d;
+        };
 
-      {/* Horizontal wave on top of RIGHT side surface */}
-      {rightWidth > 12 && (() => {
-        const segCount = Math.max(1, Math.floor((rightWidth - 4) / 8));
-        const wavePath = `M${dividerX + 2},${surfaceY} q4,-1.5 8,0` +
-          " t8,0".repeat(Math.max(0, segCount - 1));
         return (
-          <path
-            d={wavePath}
-            fill="none"
-            stroke="#6ee7b7"
-            strokeWidth={0.7}
-            opacity={0.6}
-          >
-            <animateTransform
-              attributeName="transform"
-              type="translate"
-              values="0,0; -8,0; 0,0"
-              dur="3.6s"
-              repeatCount="indefinite"
-            />
-          </path>
+          <>
+            {/* LEFT side wave */}
+            {leftWidth > 12 && (
+              <path
+                d={buildWave(poolX + padding, poolX + padding + leftWidth, surfaceY)}
+                fill="none"
+                stroke="#a5b4fc"
+                strokeWidth={0.8}
+                opacity={0.7}
+                strokeLinecap="round"
+                clipPath={`path('M${poolX + padding},${liquidTop} h${leftWidth} v${liquidH} h-${leftWidth} Z')`}
+              >
+                <animateTransform
+                  attributeName="transform"
+                  type="translate"
+                  values="0,0; -12,0; 0,0"
+                  dur="3s"
+                  repeatCount="indefinite"
+                />
+              </path>
+            )}
+            {/* RIGHT side wave */}
+            {rightWidth > 12 && (
+              <path
+                d={buildWave(dividerX, dividerX + rightWidth, surfaceY)}
+                fill="none"
+                stroke="#6ee7b7"
+                strokeWidth={0.8}
+                opacity={0.7}
+                strokeLinecap="round"
+                clipPath={`path('M${dividerX},${liquidTop} h${rightWidth} v${liquidH} h-${rightWidth} Z')`}
+              >
+                <animateTransform
+                  attributeName="transform"
+                  type="translate"
+                  values="0,0; -12,0; 0,0"
+                  dur="3.6s"
+                  repeatCount="indefinite"
+                />
+              </path>
+            )}
+          </>
         );
       })()}
 
@@ -856,6 +885,16 @@ export function CrossChainFlowViz({
   const localWidth = (splitPercent / 100) * 3 + 0.5;
   const remoteWidth = ((100 - splitPercent) / 100) * 3 + 0.5;
 
+  // Pool sizes scale with relative liquidity. Bigger pool = full size (1.0),
+  // smaller pool = sqrt of the ratio so the difference is visible but not extreme.
+  const l1Liq = l1ReserveA ? parseFloat(l1ReserveA) : 0;
+  const l2Liq = l2ReserveA ? parseFloat(l2ReserveA) : 0;
+  const maxLiq = Math.max(l1Liq, l2Liq, 1);
+  // Use sqrt to soften the visual difference (a 2x liquidity ratio → ~1.41x size).
+  // Floor at 0.55 so even tiny pools stay readable.
+  const l1Scale = Math.max(0.55, Math.sqrt(l1Liq / maxLiq) || 0.55);
+  const l2Scale = Math.max(0.55, Math.sqrt(l2Liq / maxLiq) || 0.55);
+
   // Determine which nodes are active based on phase
   const activeNodes = useMemo(() => {
     const set = new Set<string>();
@@ -1035,6 +1074,7 @@ export function CrossChainFlowViz({
           reserveB={l1ReserveB}
           chain="l1"
           active={vizPhase >= 2 && vizPhase <= 4}
+          scale={l1Scale}
         />
         <LiquidPool
           x={600}
@@ -1043,6 +1083,7 @@ export function CrossChainFlowViz({
           reserveB={l2ReserveB}
           chain="l2"
           active={vizPhase >= 5 && vizPhase <= 6}
+          scale={l2Scale}
         />
 
         {/* ══════════════ Layer 4: Bridge Portals ══════════════ */}

--- a/ui/src/components/Header.module.css
+++ b/ui/src/components/Header.module.css
@@ -91,7 +91,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  overflow-x: auto;
+  overflow: hidden;
   white-space: nowrap;
   font-family: var(--mono);
   font-size: 11px;

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -49,6 +49,8 @@ export const config = {
   reverseExecutorL1: params.get("reverseExecutorL1") || "",
   /** Faucet address — loaded from /shared/rollup.env or URL param */
   faucetAddress: params.get("faucetAddress") || "",
+  /** L2 CrossChainManager address — loaded from rollup.env */
+  ccmL2Address: params.get("ccmL2") || "",
   /** Aggregator contract addresses (loaded from rollup.env) */
   aggWeth: params.get("aggWeth") || "",
   aggUsdc: params.get("aggUsdc") || "",

--- a/ui/src/hooks/useAggregator.ts
+++ b/ui/src/hooks/useAggregator.ts
@@ -314,18 +314,37 @@ export function useAggregator(
         const wethRaw = results[8] ? decodeUint256Result(results[8] as string) : null;
         const usdcRaw = results[9] ? decodeUint256Result(results[9] as string) : null;
 
+        // Quote handling at extremes — when local or remote amount is 0
+        // (slider at 0%/100% or empty input), we MUST set the corresponding
+        // quote to "0" rather than leaving the stale previous value behind.
+        const l1QuoteFinal =
+          l1QuoteRaw !== null
+            ? formatTokenAmount(l1QuoteRaw, USDC_DECIMALS)
+            : localWei === 0n
+              ? "0"
+              : null;
+        const l2QuoteFinal =
+          l2QuoteRaw !== null
+            ? formatTokenAmount(l2QuoteRaw, USDC_DECIMALS)
+            : remoteWei === 0n
+              ? "0"
+              : null;
+        const singleFinal =
+          singleQuoteRaw !== null
+            ? formatTokenAmount(singleQuoteRaw, USDC_DECIMALS)
+            : totalWei === 0n
+              ? "0"
+              : null;
+
         setState((prev) => ({
           ...prev,
           l1ReserveA: l1ResA !== null ? formatTokenAmount(l1ResA, WETH_DECIMALS) : prev.l1ReserveA,
           l1ReserveB: l1ResB !== null ? formatTokenAmount(l1ResB, USDC_DECIMALS) : prev.l1ReserveB,
           l2ReserveA: l2ResA !== null ? formatTokenAmount(l2ResA, WETH_DECIMALS) : prev.l2ReserveA,
           l2ReserveB: l2ResB !== null ? formatTokenAmount(l2ResB, USDC_DECIMALS) : prev.l2ReserveB,
-          l1Quote: l1QuoteRaw !== null ? formatTokenAmount(l1QuoteRaw, USDC_DECIMALS) : prev.l1Quote,
-          l2Quote: l2QuoteRaw !== null ? formatTokenAmount(l2QuoteRaw, USDC_DECIMALS) : prev.l2Quote,
-          singlePoolQuote:
-            singleQuoteRaw !== null
-              ? formatTokenAmount(singleQuoteRaw, USDC_DECIMALS)
-              : prev.singlePoolQuote,
+          l1Quote: l1QuoteFinal !== null ? l1QuoteFinal : prev.l1Quote,
+          l2Quote: l2QuoteFinal !== null ? l2QuoteFinal : prev.l2Quote,
+          singlePoolQuote: singleFinal !== null ? singleFinal : prev.singlePoolQuote,
           ethBalance: ethRaw !== null ? formatTokenAmount(ethRaw, WETH_DECIMALS) : prev.ethBalance,
           wethBalance:
             wethRaw !== null ? formatTokenAmount(wethRaw, WETH_DECIMALS) : prev.wethBalance,

--- a/ui/src/hooks/useAggregator.ts
+++ b/ui/src/hooks/useAggregator.ts
@@ -58,6 +58,7 @@ export interface AggregatorState {
   l1GasUsed: string | null;
   l2BlockBefore: number | null;
   l2BlockAfter: number | null;
+  l2TxHashes: string[];
   l1Done: boolean;
   l2Done: boolean;
   // Results
@@ -105,6 +106,7 @@ const INITIAL_STATE: AggregatorState = {
   l1GasUsed: null,
   l2BlockBefore: null,
   l2BlockAfter: null,
+  l2TxHashes: [],
   l1Done: false,
   l2Done: false,
   localOutput: null,
@@ -485,6 +487,16 @@ export function useAggregator(
       const totalWei = parseTokenAmount(totalAmount, WETH_DECIMALS);
       const localWei = (totalWei * BigInt(splitPercent)) / 100n;
 
+      // Snapshot the predicted quotes BEFORE the swap. The polling loop
+      // updates `state.l1Quote` / `state.l2Quote` / `state.singlePoolQuote`
+      // continuously based on current AMM reserves, so by the time we read
+      // them in the verify phase the reserves have already changed. We need
+      // the BEFORE values for the improvement calculation and for the
+      // L1/L2 output rows in the results card.
+      const l1QuoteSnapshot = stateRef.current.l1Quote;
+      const l2QuoteSnapshot = stateRef.current.l2Quote;
+      const singlePoolSnapshot = stateRef.current.singlePoolQuote;
+
       // Reset execution state
       setState((s) => ({
         ...s,
@@ -496,6 +508,7 @@ export function useAggregator(
         l1GasUsed: null,
         l2BlockBefore: null,
         l2BlockAfter: null,
+        l2TxHashes: [],
         l1Done: false,
         l2Done: false,
         localOutput: null,
@@ -732,15 +745,14 @@ export function useAggregator(
       const totalOutputStr = formatTokenAmount(totalOutput > 0n ? totalOutput : 0n, USDC_DECIMALS);
       const usdcAfterStr = formatTokenAmount(usdcAfter, USDC_DECIMALS);
 
-      // Compute improvement vs single pool
-      const singleQuoteStr = stateRef.current.singlePoolQuote;
+      // Use the BEFORE snapshot for the improvement calculation, not the
+      // current polled value (which was computed against post-swap reserves).
       let improvementStr: string | null = null;
-      if (singleQuoteStr && totalOutput > 0n) {
+      if (singlePoolSnapshot && totalOutput > 0n) {
         try {
-          const singleQuoteWei = parseTokenAmount(singleQuoteStr, USDC_DECIMALS);
+          const singleQuoteWei = parseTokenAmount(singlePoolSnapshot, USDC_DECIMALS);
           if (singleQuoteWei > 0n) {
             const diff = totalOutput - singleQuoteWei;
-            // Multiply by 100_000 for 3 decimal places, then divide
             const pctX1000 = (diff * 100000n) / singleQuoteWei;
             const pctFloat = Number(pctX1000) / 1000;
             const sign = pctFloat >= 0 ? "+" : "";
@@ -751,6 +763,38 @@ export function useAggregator(
         }
       }
 
+      // Fetch L2 protocol transactions in the affected blocks. The cross-chain
+      // delivery txs are protocol txs from the builder address (dev#0) targeting
+      // the CCM. We grab all txs in the range [l2BlockBefore+1, l2BlockAfter]
+      // whose `from` matches the builder.
+      const BUILDER_ADDR = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+      const l2TxHashes: string[] = [];
+      try {
+        const before = stateRef.current.l2BlockBefore;
+        const after = stateRef.current.l2BlockAfter;
+        if (before !== null && after !== null && after > before) {
+          for (let bn = before + 1; bn <= after; bn++) {
+            try {
+              const block = (await rpcCall(config.l2Rpc, "eth_getBlockByNumber", [
+                "0x" + bn.toString(16),
+                true,
+              ])) as { transactions?: Array<{ hash: string; from: string }> } | null;
+              if (block?.transactions) {
+                for (const tx of block.transactions) {
+                  if (tx.from?.toLowerCase() === BUILDER_ADDR) {
+                    l2TxHashes.push(tx.hash);
+                  }
+                }
+              }
+            } catch {
+              /* skip block on error */
+            }
+          }
+        }
+      } catch {
+        /* non-critical */
+      }
+
       const endTime = Date.now();
 
       fastForwardViz(8);
@@ -758,9 +802,15 @@ export function useAggregator(
       setState((s) => ({
         ...s,
         phase: "complete",
+        // Local/remote outputs are the BEFORE snapshots (the predicted quotes).
+        // For an atomic single-tx swap with no concurrent activity these are
+        // exactly what the AMMs delivered.
+        localOutput: l1QuoteSnapshot,
+        remoteOutput: l2QuoteSnapshot,
         totalOutput: totalOutputStr,
         usdcBalanceAfter: usdcAfterStr,
         improvement: improvementStr,
+        l2TxHashes,
         endTime,
       }));
 

--- a/ui/src/hooks/useAggregator.ts
+++ b/ui/src/hooks/useAggregator.ts
@@ -58,6 +58,7 @@ export interface AggregatorState {
   l1GasUsed: string | null;
   l2BlockBefore: number | null;
   l2BlockAfter: number | null;
+  l2BlockNumber: number | null;
   l2TxHashes: string[];
   l1Done: boolean;
   l2Done: boolean;
@@ -106,6 +107,7 @@ const INITIAL_STATE: AggregatorState = {
   l1GasUsed: null,
   l2BlockBefore: null,
   l2BlockAfter: null,
+  l2BlockNumber: null,
   l2TxHashes: [],
   l1Done: false,
   l2Done: false,
@@ -508,6 +510,7 @@ export function useAggregator(
         l1GasUsed: null,
         l2BlockBefore: null,
         l2BlockAfter: null,
+        l2BlockNumber: null,
         l2TxHashes: [],
         l1Done: false,
         l2Done: false,
@@ -763,26 +766,35 @@ export function useAggregator(
         }
       }
 
-      // Fetch L2 protocol transactions in the affected blocks. The cross-chain
-      // delivery txs are protocol txs from the builder address (dev#0) targeting
-      // the CCM. We grab all txs in the range [l2BlockBefore+1, l2BlockAfter]
-      // whose `from` matches the builder.
-      const BUILDER_ADDR = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
-      const l2TxHashes: string[] = [];
+      // Fetch the SINGLE L2 cross-chain delivery tx and its block. The
+      // builder posts an `executeIncomingCrossChainCall` (selector 0x0f64c845)
+      // tx targeting the CCM that delivers our cross-chain calls. We scan
+      // L2 blocks in [l2BlockBefore+1, l2BlockAfter] for the first such tx.
+      const EXEC_INCOMING_SELECTOR = "0x0f64c845";
+      const ccmL2 = config.ccmL2Address.toLowerCase();
+      let l2TxHash: string | null = null;
+      let l2BlockHit: number | null = null;
       try {
         const before = stateRef.current.l2BlockBefore;
         const after = stateRef.current.l2BlockAfter;
-        if (before !== null && after !== null && after > before) {
-          for (let bn = before + 1; bn <= after; bn++) {
+        if (before !== null && after !== null && after > before && ccmL2) {
+          for (let bn = before + 1; bn <= after && !l2TxHash; bn++) {
             try {
               const block = (await rpcCall(config.l2Rpc, "eth_getBlockByNumber", [
                 "0x" + bn.toString(16),
                 true,
-              ])) as { transactions?: Array<{ hash: string; from: string }> } | null;
+              ])) as {
+                transactions?: Array<{ hash: string; to: string | null; input: string }>;
+              } | null;
               if (block?.transactions) {
                 for (const tx of block.transactions) {
-                  if (tx.from?.toLowerCase() === BUILDER_ADDR) {
-                    l2TxHashes.push(tx.hash);
+                  if (
+                    tx.to?.toLowerCase() === ccmL2 &&
+                    tx.input?.toLowerCase().startsWith(EXEC_INCOMING_SELECTOR)
+                  ) {
+                    l2TxHash = tx.hash;
+                    l2BlockHit = bn;
+                    break;
                   }
                 }
               }
@@ -794,6 +806,7 @@ export function useAggregator(
       } catch {
         /* non-critical */
       }
+      const l2TxHashes = l2TxHash ? [l2TxHash] : [];
 
       const endTime = Date.now();
 
@@ -811,6 +824,7 @@ export function useAggregator(
         usdcBalanceAfter: usdcAfterStr,
         improvement: improvementStr,
         l2TxHashes,
+        l2BlockNumber: l2BlockHit,
         endTime,
       }));
 

--- a/ui/src/hooks/useConfig.ts
+++ b/ui/src/hooks/useConfig.ts
@@ -56,6 +56,8 @@ export function useConfigLoader() {
             setConfig({ reverseExecutorL1: env["REVERSE_EXECUTOR_L1"] });
           if (!config.faucetAddress && env["FAUCET_ADDRESS"])
             setConfig({ faucetAddress: env["FAUCET_ADDRESS"] });
+          if (!config.ccmL2Address && env["CROSS_CHAIN_MANAGER_ADDRESS"])
+            setConfig({ ccmL2Address: env["CROSS_CHAIN_MANAGER_ADDRESS"] });
           // Aggregator addresses
           if (!config.aggWeth && env["AGG_WETH_ADDRESS"])
             setConfig({ aggWeth: env["AGG_WETH_ADDRESS"] });

--- a/ui/src/hooks/useWallet.ts
+++ b/ui/src/hooks/useWallet.ts
@@ -26,14 +26,25 @@ export function useWallet(log: Logger) {
       rpcCall(config.l2Rpc, "eth_getBalance", [address, "latest"]),
     ]);
 
-    const l1Bal =
-      l1Result.status === "fulfilled"
-        ? (parseInt(l1Result.value as string, 16) / 1e18).toFixed(4)
-        : null;
-    const l2Bal =
-      l2Result.status === "fulfilled"
-        ? (parseInt(l2Result.value as string, 16) / 1e18).toFixed(4)
-        : null;
+    // Use BigInt for precision — parseInt + /1e18 loses precision for
+    // values above ~2^53 wei (which includes the CCM's 1M ETH genesis pre-mint).
+    const formatEth = (hex: string): string => {
+      try {
+        const wei = BigInt(hex);
+        const ONE_ETH = 10n ** 18n;
+        const whole = wei / ONE_ETH;
+        // Cap unreasonable balances (e.g. CCM with 1M ETH pre-mint)
+        if (whole > 10n ** 9n) return "∞";
+        const frac = wei % ONE_ETH;
+        const fracStr = frac.toString().padStart(18, "0").slice(0, 4);
+        return `${whole.toString()}.${fracStr}`;
+      } catch {
+        return "—";
+      }
+    };
+
+    const l1Bal = l1Result.status === "fulfilled" ? formatEth(l1Result.value as string) : null;
+    const l2Bal = l2Result.status === "fulfilled" ? formatEth(l2Result.value as string) : null;
 
     setState((s) => ({ ...s, l1Balance: l1Bal, l2Balance: l2Bal }));
   }, []);


### PR DESCRIPTION
## Summary

Iterative polish of the cross-chain aggregator showcase that landed in the previous PR. 18 commits covering layout, particle animation, pool visualization, swap form ergonomics, and result correctness.

## Layout

- **Merged card**: visualization SVG and swap form now share a single `mainCard`. Compact header strip on top (badge + title + inline stats + balances), viz on the left (3/4), swap form on the right (1/4). Stacks to one column on mobile (≤1024px).
- **Execution Progress + Aggregation Results** sit side by side above ContractLanes. ContractLanes moved to the bottom (least important info).
- **Under the Hood** redesigned as an always-expanded visual explainer with 4 hop cards in a 2x2 grid + facts row.
- Removed the ✗ Compare/Route Duel button.

## Visualization (`CrossChainFlowViz`)

- **Box sizes 120×50 → 160×64** to fill the wider 3/4 column. Bigger labels (14px node title), pool labels promoted to 13px.
- **Coordinated journey particles**: a single particle leaves User as WETH, splits at the Aggregator into local + remote branches, both arrive at Output simultaneously. Labels follow each particle (WETH → USDC on local, WETH → wWETH → wUSDC → USDC on remote). 12s cycle (10s journey + 2s pause).
- **Particle loop reliability**: replaced `cycleClock`-relative `begin` events with explicit begin time lists (50 cycles built upfront) so the loop survives browser tab throttling.
- **Labels**: lighter weight (500), no stroke outline, plain colored text — clean and elegant.
- **Liquid pools** rewritten:
  - Both containers always 50/50 horizontally (Uniswap V2 invariant — both sides have equal value).
  - Liquid level `fillRatio` proportional to relative TVL (bigger pool more full).
  - Vertical divider spans full container height.
  - Symmetric quadratic bezier waves anchored to the actual liquid surface.
  - Token labels show real names (WETH/USDC on L1, wWETH/wUSDC on L2).
- **Bridge portals** larger (r=32/24/16), depth counter and direction arrows added.
- Particles + labels render LAST so they paint on top of nodes and pools.

## Swap form

- **Compact Uniswap-style** FROM/TO boxes with token chips and MAX button.
- **Wrap/Unwrap mini-bar** always visible (was hidden behind a toggle). Stacked vertical layout: label + Wrap row + Unwrap row.
- **Smaller \"You pay\"/\"You receive\" font** (28 → 20px) — was disproportionate.
- **Compact split slider**: \`L1 X% · Route split · L2 Y%\`.

## Aggregation Results

- **Local/Remote outputs now actually populated**: `localOutput`/`remoteOutput` were declared in state but never set, so the rows never rendered. Now snapshotted from `l1Quote`/`l2Quote` at execute() start.
- **Improvement % fixed**: `singlePoolQuote` was polled continuously, so the verify-phase read was computed against POST-swap reserves. Now snapshotted at execute() start.
- **L2 transaction + L2 block** added. Filtered to the single `executeIncomingCrossChainCall` (selector `0x0f64c845`) targeting the CCM L2 — that's the cross-chain delivery tx that runs the L2 swap. Mirrors the existing L1 Block + L1 Tx rows.
- **Removed**: Gas Used row, Compare button.

## Misc

- **Quote calculation at slider extremes**: bug where slider at 0% or 100% kept stale `prev.l1Quote`/`prev.l2Quote` from the polling. Now sets explicit `\"0\"` when local/remote amount is 0.
- **Wallet balance precision**: `parseInt(hex, 16) / 1e18` lost precision above ~2^53 wei (showing `9.04e+56 ETH` for huge balances). Replaced with BigInt math, capped to `\"∞\"` for >1B ETH.
- **Header scrollbar**: removed `overflow-x: auto` from `.center` that was creating a visible scrollbar artifact.
- **Demo mode removal residue**: header `_center_` class artifacts cleaned up.
- **\"3 hops\" → \"2 hops\"**: only 2 actual cross-chain crossings (L1→L2 forward + L2→L1 return). 4 cards in Under the Hood are 4 STEPS, only 2 are hops.
- **\"depth 7\" removed**: was a protocol-internal detail not meaningful for users.
- **WETH/USDC decimals fixed**: `TOKEN_DECIMALS = 18` was used for everything. USDC has 6 decimals — split into `WETH_DECIMALS = 18` and `USDC_DECIMALS = 6`, all formatTokenAmount/parseTokenAmount sites updated.

## Test plan

- [x] Build: `npm run build` clean, no TypeScript errors
- [x] Visual inspection: viz, swap form, results card, under the hood
- [x] Particle animation: visible 1+ time per minute (12s cycle), labels readable
- [x] Pool fill levels reflect L1 vs L2 liquidity ratio
- [x] Slider 0% / 50% / 100%: quotes correct, total = L1 + L2 quote, no stale values
- [x] Aggregated swap end-to-end: L1 + L2 tx hashes captured, improvement % positive
- [x] Wrap ETH → WETH and Unwrap WETH → ETH work from the always-visible bar
- [x] Mobile breakpoint (≤1024px): viz stacks above swap form

🤖 Generated with [Claude Code](https://claude.com/claude-code)