### PR TITLE
fix(ci): pin reth Docker image to v1.11.3

### DIFF
--- a/deployments/ci-local/docker-compose.yml
+++ b/deployments/ci-local/docker-compose.yml
@@ -24,7 +24,9 @@
 services:
   # L1 — local Ethereum node (reth --dev mode)
   l1:
-    image: ghcr.io/paradigmxyz/reth:latest
+    # Pinned to v1.11.3 (matches Cargo.toml reth crate pin on the 1.11.x line).
+    # NEVER use :latest — reth 2.0.0 (2026-04-07) breaks withdrawal trigger flow.
+    image: ghcr.io/paradigmxyz/reth:v1.11.3
     command:
       - node
       - --dev

--- a/deployments/devnet-eez/docker-compose.yml
+++ b/deployments/devnet-eez/docker-compose.yml
@@ -24,7 +24,9 @@
 services:
   # L1 — local Ethereum node (reth --dev mode)
   l1:
-    image: ghcr.io/paradigmxyz/reth:latest
+    # Pinned to v1.11.3 (matches Cargo.toml reth crate pin on the 1.11.x line).
+    # NEVER use :latest — reth 2.0.0 (2026-04-07) breaks withdrawal trigger flow.
+    image: ghcr.io/paradigmxyz/reth:v1.11.3
     command:
       - node
       - --dev

--- a/deployments/kurtosis-1337/network_params.yaml
+++ b/deployments/kurtosis-1337/network_params.yaml
@@ -10,7 +10,9 @@ participants:
   # Two Lighthouse nodes with 256 validators each (512 total).
   # Large validator set ensures committees have enough members for 2/3 supermajority.
   - el_type: reth
-    el_image: ghcr.io/paradigmxyz/reth:latest
+    # Pinned to v1.11.3 (matches Cargo.toml reth crate pin on the 1.11.x line).
+    # NEVER use :latest — reth 2.0.0 (2026-04-07) breaks withdrawal trigger flow.
+    el_image: ghcr.io/paradigmxyz/reth:v1.11.3
     cl_type: lighthouse
     cl_image: sigp/lighthouse:latest
     cl_extra_params:

--- a/deployments/testnet-eez/docker-compose.yml
+++ b/deployments/testnet-eez/docker-compose.yml
@@ -13,7 +13,9 @@
 services:
   # L1 — local Ethereum node (reth --dev mode)
   l1:
-    image: ghcr.io/paradigmxyz/reth:latest
+    # Pinned to v1.11.3 (matches Cargo.toml reth crate pin on the 1.11.x line).
+    # NEVER use :latest — reth 2.0.0 (2026-04-07) breaks withdrawal trigger flow.
+    image: ghcr.io/paradigmxyz/reth:v1.11.3
     command:
       - node
       - --dev


### PR DESCRIPTION
Pins ghcr.io/paradigmxyz/reth to v1.11.3 in all 4 deployment compose files. Previously all used `:latest`, which silently upgraded to reth 2.0.0 on 2026-04-07 ~13:05 UTC and broke the L2→L1 withdrawal trigger flow on main CI.

Evidence for the break:
- Same PR branch (commit 6d09ae1) passed CI on the PR run at 13:23 UTC but the identical-tree merge commit (b31f1d0) failed on main CI at 14:05 and again on rerun at 15:25 — always the same 9 failures (TEST 12/15/17/18 in bridge-health-check.sh). Both runs pulled reth 2.0.0 as :latest.
- Reproduced locally: devnet with b31f1d0 binary + reth 1.11.3 (cached from 2026-03-12) passes 71/71; same devnet after pulling reth 2.0.0 fresh reproduces the exact CI failures.
- reth 2.0.0 has breaking changes on the withdrawal trigger flow (receipt polling / mempool / tx confirmation behavior); the exact root cause in reth is out of scope here.

Why v1.11.3:
- The Cargo.toml reth crate is pinned to commit 39b9c8ae (dated 2026-03-05, between v1.11.2 and v1.11.3), on the reth 1.11.x line.
- v1.11.3 Docker tag digest sha256:523e5c6a matches what my local containers had cached and tested clean.
- Keeps the L1 reth --dev binary and our L2 builder crate on the same reth 1.11.x API surface.

Files:
- deployments/testnet-eez/docker-compose.yml  (used by CI)
- deployments/devnet-eez/docker-compose.yml
- deployments/ci-local/docker-compose.yml
- deployments/kurtosis-1337/network_params.yaml

Each line carries a comment with the reason, so future "upgrade to :latest" attempts have context.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Related Issues

<!-- Link issues this PR addresses: Closes #123, Fixes #456 -->

## Testing

- [ ] Unit tests pass (`cargo test --workspace --lib`)
- [ ] E2E tests pass (`cargo test --workspace --test e2e_anvil`)
- [ ] Clippy clean (`cargo clippy --workspace --all-features`)
- [ ] Formatted (`cargo +nightly fmt --all --check`)

## Review Checklist

- [ ] No `unwrap()` in production code without justification
- [ ] No unchecked arithmetic on untrusted inputs
- [ ] Error paths logged appropriately
- [ ] No hardcoded secrets or keys
