### PR TITLE
test: arb bot reproducer for issue #29

### DIFF
--- a/contracts/test-multi-call/foundry.toml
+++ b/contracts/test-multi-call/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "src"
+out = "out"
+cache_path = "cache"
+solc_version = "0.8.33"
+via_ir = true
+optimizer = true
+optimizer_runs = 200

--- a/contracts/test-multi-call/src/CrossChainArb.sol
+++ b/contracts/test-multi-call/src/CrossChainArb.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC20 {
+    function balanceOf(address) external view returns (uint256);
+    function approve(address, uint256) external returns (bool);
+    function transfer(address, uint256) external returns (bool);
+}
+
+interface IAMM {
+    function swap(address tokenIn, uint256 amountIn) external returns (uint256);
+}
+
+interface IBridge {
+    function bridgeTokens(address token, uint256 amount, uint256 rollupId, address dest) external;
+}
+
+interface IL2Executor {
+    function swapAndBridgeBack(address tokenIn, address recipient) external returns (uint256);
+}
+
+/// @title CrossChainArb
+/// @notice Atomic cross-chain arbitrage between L1 and L2 AMM pools.
+///         Holds its own working capital (WETH). Bot off-chain decides direction
+///         and size. Each arb is atomic — reverts if profit < minProfit.
+///
+///         Two directions:
+///         - arbSellOnL2: bridge WETH to L2, sell WETH→USDC on L2, bridge USDC back,
+///                        buy WETH→USDC on L1. Profitable when L2 WETH price > L1 WETH price.
+///         - arbSellOnL1: swap WETH→USDC on L1, bridge USDC to L2, L2 swaps USDC→WETH,
+///                        bridge WETH back. Profitable when L1 WETH price > L2 WETH price.
+contract CrossChainArb {
+    address public weth;
+    address public usdc;
+    address public l1Amm;
+    address public bridge;
+    uint256 public rollupId;
+    address public l2Executor;
+    address public l2ExecutorProxy;
+    address public owner;
+
+    event ArbExecuted(uint8 direction, uint256 amountIn, uint256 profit);
+
+    constructor(
+        address _weth,
+        address _usdc,
+        address _l1Amm,
+        address _bridge,
+        uint256 _rollupId
+    ) {
+        weth = _weth;
+        usdc = _usdc;
+        l1Amm = _l1Amm;
+        bridge = _bridge;
+        rollupId = _rollupId;
+        owner = msg.sender;
+    }
+
+    function setL2Executor(address _executor, address _proxy) external {
+        require(msg.sender == owner, "only owner");
+        l2Executor = _executor;
+        l2ExecutorProxy = _proxy;
+    }
+
+    /// @notice Sell WETH on L2 (expensive), buy WETH on L1 (cheap).
+    ///         Profitable when L2 price > L1 price.
+    function arbSellOnL2(uint256 amountIn, uint256 minProfit) external returns (uint256 profit) {
+        require(msg.sender == owner, "only owner");
+        uint256 balBefore = IERC20(weth).balanceOf(address(this));
+        require(balBefore >= amountIn, "insufficient WETH");
+
+        // 1. Bridge WETH to L2 Executor
+        IERC20(weth).approve(bridge, amountIn);
+        IBridge(bridge).bridgeTokens(weth, amountIn, rollupId, l2Executor);
+
+        // 2. Call L2 Executor via proxy: swaps WETH→USDC on L2, bridges USDC back here
+        uint256 usdcBefore = IERC20(usdc).balanceOf(address(this));
+        (bool ok,) = l2ExecutorProxy.call(
+            abi.encodeCall(IL2Executor.swapAndBridgeBack, (weth, address(this)))
+        );
+        require(ok, "L2 executor call failed");
+        uint256 usdcReceived = IERC20(usdc).balanceOf(address(this)) - usdcBefore;
+        require(usdcReceived > 0, "no USDC received");
+
+        // 3. Swap USDC → WETH on L1 AMM
+        IERC20(usdc).approve(l1Amm, usdcReceived);
+        IAMM(l1Amm).swap(usdc, usdcReceived);
+
+        // 4. Profit check
+        uint256 balAfter = IERC20(weth).balanceOf(address(this));
+        require(balAfter >= balBefore + minProfit, "unprofitable");
+        profit = balAfter - balBefore;
+        emit ArbExecuted(0, amountIn, profit);
+    }
+
+    /// @notice Sell WETH on L1 (expensive), buy WETH on L2 (cheap).
+    ///         Profitable when L1 price > L2 price.
+    function arbSellOnL1(uint256 amountIn, uint256 minProfit) external returns (uint256 profit) {
+        require(msg.sender == owner, "only owner");
+        uint256 balBefore = IERC20(weth).balanceOf(address(this));
+        require(balBefore >= amountIn, "insufficient WETH");
+
+        // 1. Swap WETH → USDC on L1 AMM
+        IERC20(weth).approve(l1Amm, amountIn);
+        uint256 usdcOut = IAMM(l1Amm).swap(weth, amountIn);
+
+        // 2. Bridge USDC to L2 Executor
+        IERC20(usdc).approve(bridge, usdcOut);
+        IBridge(bridge).bridgeTokens(usdc, usdcOut, rollupId, l2Executor);
+
+        // 3. Call L2 Executor via proxy: swaps USDC→WETH on L2, bridges WETH back here
+        (bool ok,) = l2ExecutorProxy.call(
+            abi.encodeCall(IL2Executor.swapAndBridgeBack, (usdc, address(this)))
+        );
+        require(ok, "L2 executor call failed");
+
+        // 4. Profit check
+        uint256 balAfter = IERC20(weth).balanceOf(address(this));
+        require(balAfter >= balBefore + minProfit, "unprofitable");
+        profit = balAfter - balBefore;
+        emit ArbExecuted(1, amountIn, profit);
+    }
+
+    /// @notice Owner withdraw — for recovering funds.
+    function withdraw(address token, uint256 amount) external {
+        require(msg.sender == owner, "only owner");
+        IERC20(token).transfer(owner, amount);
+    }
+}

--- a/contracts/test-multi-call/src/L2Executor.sol
+++ b/contracts/test-multi-call/src/L2Executor.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC20 {
+    function balanceOf(address) external view returns (uint256);
+    function approve(address, uint256) external returns (bool);
+    function transfer(address, uint256) external returns (bool);
+}
+
+interface IAMM {
+    function swap(address tokenIn, uint256 amountIn) external returns (uint256);
+}
+
+interface IBridge {
+    function bridgeTokens(address token, uint256 amount, uint256 rollupId, address dest) external;
+}
+
+/// @title L2Executor
+/// @notice Deployed on L2. Receives bridged tokens, swaps on L2 AMM,
+///         bridges the output back to L1.
+///         Called via cross-chain proxy from L1.
+contract L2Executor {
+    address public amm;
+    address public bridge;
+    address public tokenA;
+    address public tokenB;
+
+    constructor(address _amm, address _bridge, address _tokenA, address _tokenB) {
+        amm = _amm;
+        bridge = _bridge;
+        tokenA = _tokenA;
+        tokenB = _tokenB;
+    }
+
+    /// @notice Swap and bridge back. The `l1TokenIn` parameter is the L1 address
+    ///         of the token (passed from the L1 Aggregator via cross-chain call).
+    ///         We map it to the local L2 wrapped token address.
+    function swapAndBridgeBack(address l1TokenIn, address recipient) external returns (uint256 amountOut) {
+        // Map L1 token address to L2 wrapped token address.
+        // The bridge deposit already delivered wrapped tokens to this contract.
+        // We don't use l1TokenIn directly — it has no code on L2.
+        // Instead, check which of our known L2 tokens has a balance.
+        address localTokenIn;
+        if (IERC20(tokenA).balanceOf(address(this)) > 0) {
+            localTokenIn = tokenA;
+        } else if (IERC20(tokenB).balanceOf(address(this)) > 0) {
+            localTokenIn = tokenB;
+        } else {
+            revert("no tokens to swap");
+        }
+
+        uint256 balance = IERC20(localTokenIn).balanceOf(address(this));
+
+        IERC20(localTokenIn).approve(amm, balance);
+        amountOut = IAMM(amm).swap(localTokenIn, balance);
+
+        address localTokenOut = localTokenIn == tokenA ? tokenB : tokenA;
+        IERC20(localTokenOut).approve(bridge, amountOut);
+        IBridge(bridge).bridgeTokens(localTokenOut, amountOut, 0, recipient);
+    }
+}

--- a/contracts/test-multi-call/src/MockERC20.sol
+++ b/contracts/test-multi-call/src/MockERC20.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(string memory _name, string memory _symbol, uint8 _decimals) {
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "insufficient balance");
+        require(allowance[from][msg.sender] >= amount, "insufficient allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/contracts/test-multi-call/src/SimpleAMM.sol
+++ b/contracts/test-multi-call/src/SimpleAMM.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC20 {
+    function balanceOf(address) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function decimals() external view returns (uint8);
+    function symbol() external view returns (string memory);
+}
+
+/// @title SimpleAMM
+/// @notice Minimal constant-product AMM (x*y=k) for two ERC20 tokens.
+///         Supports addLiquidity, removeLiquidity, and swap.
+///         No LP tokens — single liquidity provider model for simplicity.
+contract SimpleAMM {
+    IERC20 public immutable tokenA;
+    IERC20 public immutable tokenB;
+    string public poolName;
+
+    uint256 public reserveA;
+    uint256 public reserveB;
+    address public liquidityProvider;
+
+    event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB);
+    event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB);
+    event Swap(address indexed user, address tokenIn, uint256 amountIn, address tokenOut, uint256 amountOut);
+
+    constructor(address _tokenA, address _tokenB) {
+        tokenA = IERC20(_tokenA);
+        tokenB = IERC20(_tokenB);
+        poolName = string(abi.encodePacked(
+            IERC20(_tokenA).symbol(), "/", IERC20(_tokenB).symbol()
+        ));
+    }
+
+    function addLiquidity(uint256 amountA, uint256 amountB) external {
+        require(amountA > 0 && amountB > 0, "zero amount");
+        tokenA.transferFrom(msg.sender, address(this), amountA);
+        tokenB.transferFrom(msg.sender, address(this), amountB);
+        reserveA += amountA;
+        reserveB += amountB;
+        liquidityProvider = msg.sender;
+        emit LiquidityAdded(msg.sender, amountA, amountB);
+    }
+
+    function removeLiquidity() external {
+        require(msg.sender == liquidityProvider, "not provider");
+        uint256 a = reserveA;
+        uint256 b = reserveB;
+        reserveA = 0;
+        reserveB = 0;
+        tokenA.transfer(msg.sender, a);
+        tokenB.transfer(msg.sender, b);
+        emit LiquidityRemoved(msg.sender, a, b);
+    }
+
+    /// @notice Swap tokenIn for tokenOut using constant product formula.
+    ///         0.3% fee applied to input.
+    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+        require(amountIn > 0, "zero input");
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "invalid token");
+
+        bool isAtoB = tokenIn == address(tokenA);
+        (uint256 resIn, uint256 resOut) = isAtoB ? (reserveA, reserveB) : (reserveB, reserveA);
+
+        // Transfer in
+        IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
+
+        // Constant product with 0.3% fee
+        uint256 amountInWithFee = amountIn * 997;
+        amountOut = (amountInWithFee * resOut) / (resIn * 1000 + amountInWithFee);
+        require(amountOut > 0, "insufficient output");
+
+        // Transfer out
+        if (isAtoB) {
+            reserveA += amountIn;
+            reserveB -= amountOut;
+            tokenB.transfer(msg.sender, amountOut);
+        } else {
+            reserveB += amountIn;
+            reserveA -= amountOut;
+            tokenA.transfer(msg.sender, amountOut);
+        }
+
+        emit Swap(msg.sender, tokenIn, amountIn, isAtoB ? address(tokenB) : address(tokenA), amountOut);
+    }
+
+    /// @notice Get quote for a swap (view only, no state change)
+    function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "invalid token");
+        bool isAtoB = tokenIn == address(tokenA);
+        (uint256 resIn, uint256 resOut) = isAtoB ? (reserveA, reserveB) : (reserveB, reserveA);
+        if (resIn == 0 || resOut == 0 || amountIn == 0) return 0;
+        uint256 amountInWithFee = amountIn * 997;
+        return (amountInWithFee * resOut) / (resIn * 1000 + amountInWithFee);
+    }
+
+    /// @notice Get current price of tokenA in terms of tokenB
+    function price() external view returns (uint256) {
+        if (reserveA == 0) return 0;
+        return (reserveB * 1e18) / reserveA;
+    }
+}

--- a/scripts/arb_bot.py
+++ b/scripts/arb_bot.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Cross-chain atomic arbitrage bot.
+
+Monitors L1 and L2 AMM reserves. When prices diverge enough for profitable arb,
+computes optimal trade size, simulates, and executes the atomic arb via
+CrossChainArb.sol on L1.
+
+Continuous loop — polls every 3 seconds.
+"""
+
+import json
+import time
+import sys
+import os
+from datetime import datetime, timezone
+from web3 import Web3
+from eth_account import Account
+from eth_abi import encode, decode
+
+# ── Config ─────────────────────────────────────────────────────────────
+CFG_PATH = sys.argv[1] if len(sys.argv) > 1 else '/tmp/arb_config.json'
+with open(CFG_PATH) as f:
+    CFG = json.load(f)
+BOT_NAME = CFG.get('bot_name', 'bot1')
+
+w3_l1 = Web3(Web3.HTTPProvider(CFG['l1_rpc']))
+w3_proxy = Web3(Web3.HTTPProvider(CFG['l1_proxy']))
+w3_l2 = Web3(Web3.HTTPProvider(CFG['l2_rpc']))
+acct = Account.from_key(CFG['test_key'])
+
+# Normalize all addresses to checksum
+for k in ['arb_contract', 'weth_l1', 'usdc_l1', 'amm_l1', 'bridge',
+          'l2_executor', 'l2_executor_proxy', 'amm_l2', 'weth_l2', 'usdc_l2']:
+    CFG[k] = Web3.to_checksum_address(CFG[k])
+
+# ── Constants ───────────────────────────────────────────────────────────
+FEE_NUM = 997           # SimpleAMM fee: 0.3% → keep 99.7%
+FEE_DEN = 1000
+POLL_INTERVAL = 3       # seconds
+MIN_PROFIT_USD = 1.0    # threshold
+MAX_ARB_SIZE_WETH = 10**18  # 1 WETH = working capital, never arb more than we own
+GAS_PRICE = w3_l1.eth.gas_price
+LOG_FILE = CFG.get('log_file', '/tmp/arb_bot.log')
+HEARTBEAT_FILE = CFG.get('heartbeat_file', '/tmp/arb_bot_heartbeat.log')
+PID_FILE = CFG.get('pid_file', '/tmp/arb_bot.pid')
+
+# ── ABIs (minimal) ──────────────────────────────────────────────────────
+AMM_ABI = [
+    {"inputs": [], "name": "reserveA", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "reserveB", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "tokenA", "outputs": [{"type": "address"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "tokenB", "outputs": [{"type": "address"}], "stateMutability": "view", "type": "function"},
+]
+ERC20_ABI = [
+    {"inputs": [{"type": "address"}], "name": "balanceOf", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+]
+ARB_ABI = [
+    {"inputs": [{"type": "uint256"}, {"type": "uint256"}], "name": "arbSellOnL1", "outputs": [{"type": "uint256"}], "stateMutability": "nonpayable", "type": "function"},
+    {"inputs": [{"type": "uint256"}, {"type": "uint256"}], "name": "arbSellOnL2", "outputs": [{"type": "uint256"}], "stateMutability": "nonpayable", "type": "function"},
+]
+
+amm_l1 = w3_l1.eth.contract(address=CFG['amm_l1'], abi=AMM_ABI)
+amm_l2 = w3_l2.eth.contract(address=CFG['amm_l2'], abi=AMM_ABI)
+weth_l1 = w3_l1.eth.contract(address=CFG['weth_l1'], abi=ERC20_ABI)
+arb = w3_l1.eth.contract(address=CFG['arb_contract'], abi=ARB_ABI)
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+def log(msg):
+    ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    line = f'{ts} {msg}'
+    print(line, flush=True)
+    with open(LOG_FILE, 'a') as f:
+        f.write(line + '\n')
+
+
+def get_reserves():
+    """Return (l1_weth, l1_usdc, l2_weth, l2_usdc) — tokenA is WETH, tokenB is USDC by convention."""
+    l1a = amm_l1.functions.reserveA().call()
+    l1b = amm_l1.functions.reserveB().call()
+    l2a = amm_l2.functions.reserveA().call()
+    l2b = amm_l2.functions.reserveB().call()
+    return l1a, l1b, l2a, l2b
+
+
+def swap_out(amount_in, reserve_in, reserve_out):
+    """Constant-product AMM output for given input with 0.3% fee."""
+    if amount_in == 0:
+        return 0
+    amount_in_with_fee = amount_in * FEE_NUM
+    numerator = amount_in_with_fee * reserve_out
+    denominator = reserve_in * FEE_DEN + amount_in_with_fee
+    return numerator // denominator
+
+
+def simulate_arb_sell_on_l1(amount_weth, l1_weth, l1_usdc, l2_weth, l2_usdc):
+    """
+    Path: WETH → USDC (L1 AMM) → USDC (L2 AMM) → WETH. Returns final WETH.
+    Profit = final_weth - amount_weth.
+    """
+    usdc_out = swap_out(amount_weth, l1_weth, l1_usdc)
+    if usdc_out == 0:
+        return 0
+    # L2 AMM: tokenA=WETH, tokenB=USDC. We're swapping USDC (tokenB) for WETH (tokenA).
+    weth_out = swap_out(usdc_out, l2_usdc, l2_weth)
+    return weth_out
+
+
+def simulate_arb_sell_on_l2(amount_weth, l1_weth, l1_usdc, l2_weth, l2_usdc):
+    """
+    Path: WETH (bridged to L2) → USDC (L2 AMM) → (bridged to L1) → WETH (L1 AMM).
+    """
+    usdc_out = swap_out(amount_weth, l2_weth, l2_usdc)
+    if usdc_out == 0:
+        return 0
+    weth_out = swap_out(usdc_out, l1_usdc, l1_weth)
+    return weth_out
+
+
+def find_optimal_arb(l1_weth, l1_usdc, l2_weth, l2_usdc, max_amount):
+    """
+    Grid search + refine for optimal arb size and direction.
+    Returns (direction, amount_weth, profit_weth) — direction is 'l1' or 'l2'
+    (sell side), None if no profitable trade.
+    """
+    best = (None, 0, 0)
+
+    # Grid search over log-spaced sizes
+    sizes = []
+    for exp in range(15, int.bit_length(max_amount)):
+        v = 1 << exp
+        if v > max_amount:
+            break
+        sizes.append(v)
+    # Add mid-range fractions
+    for frac in [0.01, 0.05, 0.1, 0.2, 0.3, 0.5, 0.7, 0.9, 1.0]:
+        sizes.append(int(max_amount * frac))
+    sizes = sorted(set(s for s in sizes if 10**14 <= s <= max_amount))
+
+    for amount in sizes:
+        # Try sell on L1 first (L1 expensive, L2 cheap)
+        out = simulate_arb_sell_on_l1(amount, l1_weth, l1_usdc, l2_weth, l2_usdc)
+        profit = out - amount
+        if profit > best[2]:
+            best = ('l1', amount, profit)
+
+        # Try sell on L2 first (L2 expensive, L1 cheap)
+        out = simulate_arb_sell_on_l2(amount, l1_weth, l1_usdc, l2_weth, l2_usdc)
+        profit = out - amount
+        if profit > best[2]:
+            best = ('l2', amount, profit)
+
+    # Refine around the best size with ternary-like search
+    direction, size, profit = best
+    if direction is None:
+        return None, 0, 0
+
+    sim = simulate_arb_sell_on_l1 if direction == 'l1' else simulate_arb_sell_on_l2
+    lo, hi = max(10**14, size // 4), min(max_amount, size * 4)
+    for _ in range(30):
+        m1 = lo + (hi - lo) // 3
+        m2 = hi - (hi - lo) // 3
+        p1 = sim(m1, l1_weth, l1_usdc, l2_weth, l2_usdc) - m1
+        p2 = sim(m2, l1_weth, l1_usdc, l2_weth, l2_usdc) - m2
+        if p1 < p2:
+            lo = m1
+        else:
+            hi = m2
+        if hi - lo < 10**12:
+            break
+    amount = (lo + hi) // 2
+    profit = sim(amount, l1_weth, l1_usdc, l2_weth, l2_usdc) - amount
+    return direction, amount, profit
+
+
+def send_tx(fn_name, amount_in, min_profit):
+    """Send arb tx through L1 proxy."""
+    fn = arb.functions[fn_name](amount_in, min_profit)
+    tx = fn.build_transaction({
+        'from': acct.address,
+        'nonce': w3_proxy.eth.get_transaction_count(acct.address),
+        'gas': 5_000_000,
+        'gasPrice': GAS_PRICE,
+        'chainId': w3_proxy.eth.chain_id,
+    })
+    signed = acct.sign_transaction(tx)
+    tx_hash = w3_proxy.eth.send_raw_transaction(signed.raw_transaction)
+    receipt = w3_l1.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+    return tx_hash.hex(), receipt
+
+
+# ── State ───────────────────────────────────────────────────────────────
+state = {
+    'iterations': 0,
+    'opportunities': 0,
+    'attempts': 0,
+    'successes': 0,
+    'failures': 0,
+    'total_profit_weth': 0,
+    'total_gas_used': 0,
+    'start_time': time.time(),
+}
+
+
+def pct(a, b):
+    return f'{(a / b * 100):.3f}%' if b else '—'
+
+
+def main():
+    log(f'=== ARB BOT [{BOT_NAME}] START ===')
+    log(f'Config: {CFG_PATH}')
+    log(f'Arb contract: {CFG["arb_contract"]}')
+    log(f'Min profit: ${MIN_PROFIT_USD}')
+    log(f'Max arb size: {MAX_ARB_SIZE_WETH / 1e18} WETH')
+    log(f'Poll interval: {POLL_INTERVAL}s')
+    log(f'Gas price: {GAS_PRICE} wei')
+
+    # Read starting arb balance
+    start_bal = weth_l1.functions.balanceOf(CFG['arb_contract']).call()
+    log(f'Starting arb balance: {start_bal / 1e18} WETH')
+
+    run_until = time.time() + 24 * 3600  # 1 day
+
+    while time.time() < run_until:
+        state['iterations'] += 1
+        try:
+            l1a, l1b, l2a, l2b = get_reserves()
+
+            # Current arb balance (working capital)
+            bal = weth_l1.functions.balanceOf(CFG['arb_contract']).call()
+            max_amount = min(bal, MAX_ARB_SIZE_WETH)
+            if max_amount < 10**15:  # < 0.001 WETH — can't trade
+                log(f'[skip] arb balance too low: {bal / 1e18:.6f} WETH')
+                time.sleep(POLL_INTERVAL)
+                continue
+
+            # Compute prices (USDC per WETH, 6 decimals)
+            p_l1 = l1b / (l1a / 1e18) if l1a else 0
+            p_l2 = l2b / (l2a / 1e18) if l2a else 0
+            spread_pct = (p_l1 - p_l2) / p_l1 * 100 if p_l1 else 0
+
+            # Find optimal arb
+            direction, amount, profit_wei = find_optimal_arb(l1a, l1b, l2a, l2b, max_amount)
+
+            # Compute profit in USD (profit_wei × USDC/WETH price / 1e18 / 1e6 USDC decimals)
+            # profit is in WETH wei; convert to USDC value using the higher price
+            p_avg = max(p_l1, p_l2)  # USDC-per-WETH (in USDC ticks / WETH ticks, ticks = 1e6 and 1e18)
+            # profit_usd = profit_wei * (price) / 1e18, where price is USDC ticks per WETH wei
+            # p_avg = usdc_ticks_per_weth_wei_approx... simpler:
+            profit_weth_float = profit_wei / 1e18
+            profit_usd = profit_weth_float * p_avg  # p_avg is USDC per 1 WETH (already accounts for 1e18 scale)
+            # Convert USDC ticks to USD: p_avg is already USDC-ticks per WETH. USDC has 6 decimals.
+            profit_usd = profit_usd / 1e6
+
+            # Heartbeat line every iteration — dashboard parses this for live state.
+            # Write to a separate heartbeat file to keep the main log compact.
+            heartbeat = (f'[{state["iterations"]}] L1={p_l1/1e6:.2f} L2={p_l2/1e6:.2f} '
+                         f'spread={spread_pct:+.2f}% best={profit_usd:+.2f} USD ({direction or "none"})')
+            with open(HEARTBEAT_FILE, 'w') as f:
+                f.write(f'{datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")} {heartbeat}\n')
+            # Only write to the main log every 10th poll to avoid spam
+            if state['iterations'] % 10 == 0:
+                log(heartbeat)
+
+            if direction is None or profit_usd < MIN_PROFIT_USD:
+                time.sleep(POLL_INTERVAL)
+                continue
+
+            state['opportunities'] += 1
+            log(f'OPPORTUNITY: dir={direction} amount={amount / 1e18:.6f} WETH expected_profit={profit_usd:.2f} USD')
+
+            # Set minProfit = 80% of expected (buffer for price drift)
+            min_profit = int(profit_wei * 80 // 100)
+            fn_name = 'arbSellOnL1' if direction == 'l1' else 'arbSellOnL2'
+
+            state['attempts'] += 1
+            try:
+                tx_hash, receipt = send_tx(fn_name, amount, min_profit)
+                if receipt['status'] == 1:
+                    state['successes'] += 1
+                    state['total_gas_used'] += receipt['gasUsed']
+                    # Read actual balance change
+                    new_bal = weth_l1.functions.balanceOf(CFG['arb_contract']).call()
+                    actual_profit_wei = new_bal - bal
+                    state['total_profit_weth'] += actual_profit_wei
+                    actual_profit_usd = actual_profit_wei / 1e18 * p_avg / 1e6
+                    log(f'SUCCESS: tx={tx_hash} gas={receipt["gasUsed"]} profit={actual_profit_wei / 1e18:.6f} WETH (${actual_profit_usd:.2f})')
+                else:
+                    state['failures'] += 1
+                    log(f'REVERTED: tx={tx_hash} gas={receipt["gasUsed"]}')
+            except Exception as e:
+                state['failures'] += 1
+                log(f'SEND ERROR: {e}')
+
+            # Summary every time we attempt
+            elapsed = time.time() - state['start_time']
+            log(f'STATS: iter={state["iterations"]} opps={state["opportunities"]} '
+                f'ok={state["successes"]} fail={state["failures"]} '
+                f'profit={state["total_profit_weth"] / 1e18:.6f} WETH '
+                f'gas={state["total_gas_used"]} elapsed={elapsed:.0f}s')
+
+        except KeyboardInterrupt:
+            log('=== STOPPED ===')
+            break
+        except Exception as e:
+            log(f'ERROR: {e}')
+
+        time.sleep(POLL_INTERVAL)
+
+    log(f'=== DONE ===')
+    log(f'Iterations: {state["iterations"]}')
+    log(f'Opportunities: {state["opportunities"]}')
+    log(f'Attempts: {state["attempts"]}')
+    log(f'Successes: {state["successes"]} / Failures: {state["failures"]}')
+    log(f'Total profit: {state["total_profit_weth"] / 1e18:.6f} WETH')
+    log(f'Total gas used: {state["total_gas_used"]}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/arb_dashboard.py
+++ b/scripts/arb_dashboard.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""
+Dashboard for the cross-chain arb bot.
+
+Serves a simple HTML page that shows:
+- Live L1 and L2 AMM prices + reserves
+- Spread between them
+- Bot stats (iterations, opportunities, successes, total profit)
+- Recent bot log lines
+
+Run: python3 scripts/arb_dashboard.py
+Then open: http://localhost:8765/
+"""
+
+import json
+import os
+import re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from web3 import Web3
+
+CONFIG_PATHS = ['/tmp/arb_config.json', '/tmp/arb_config_2.json']
+TRADER_LOG = '/tmp/trader.log'
+TRADER_PID = '/tmp/trader.pid'
+PORT = 8765
+
+BOTS = []
+for p in CONFIG_PATHS:
+    if not os.path.exists(p):
+        continue
+    with open(p) as f:
+        c = json.load(f)
+    for k in ['arb_contract', 'weth_l1', 'usdc_l1', 'amm_l1', 'amm_l2']:
+        c[k] = Web3.to_checksum_address(c[k])
+    BOTS.append(c)
+
+CFG = BOTS[0]  # first bot holds shared addresses for the AMMs
+
+w3_l1 = Web3(Web3.HTTPProvider(CFG['l1_rpc']))
+w3_l2 = Web3(Web3.HTTPProvider(CFG['l2_rpc']))
+
+AMM_ABI = [
+    {"inputs": [], "name": "reserveA", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "reserveB", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+]
+ERC20_ABI = [
+    {"inputs": [{"type": "address"}], "name": "balanceOf", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+]
+
+amm_l1 = w3_l1.eth.contract(address=CFG['amm_l1'], abi=AMM_ABI)
+amm_l2 = w3_l2.eth.contract(address=CFG['amm_l2'], abi=AMM_ABI)
+weth_l1 = w3_l1.eth.contract(address=CFG['weth_l1'], abi=ERC20_ABI)
+usdc_l1 = w3_l1.eth.contract(address=CFG['usdc_l1'], abi=ERC20_ABI)
+
+
+def get_state():
+    l1a = amm_l1.functions.reserveA().call()
+    l1b = amm_l1.functions.reserveB().call()
+    l2a = amm_l2.functions.reserveA().call()
+    l2b = amm_l2.functions.reserveB().call()
+
+    p_l1 = (l1b / 1e6) / (l1a / 1e18) if l1a else 0
+    p_l2 = (l2b / 1e6) / (l2a / 1e18) if l2a else 0
+    spread = (p_l1 - p_l2) / ((p_l1 + p_l2) / 2) * 100 if (p_l1 + p_l2) else 0
+
+    bots = []
+    for cfg in BOTS:
+        weth_bal = weth_l1.functions.balanceOf(cfg['arb_contract']).call()
+        usdc_bal = usdc_l1.functions.balanceOf(cfg['arb_contract']).call()
+        stats = parse_log(cfg)
+        bots.append({
+            'name': cfg.get('bot_name', 'bot'),
+            'address': cfg['arb_contract'],
+            'weth_balance': weth_bal / 1e18,
+            'usdc_balance': usdc_bal / 1e6,
+            **stats,
+        })
+
+    trader = parse_trader_log()
+
+    return {
+        'l1': {'weth': l1a / 1e18, 'usdc': l1b / 1e6, 'price': p_l1},
+        'l2': {'weth': l2a / 1e18, 'usdc': l2b / 1e6, 'price': p_l2},
+        'spread_pct': spread,
+        'bots': bots,
+        'trader': trader,
+    }
+
+
+def parse_trader_log():
+    out = {'running': False, 'lines': [], 'trades': 0}
+    if not os.path.exists(TRADER_PID):
+        return out
+    try:
+        with open(TRADER_PID) as f:
+            pid = int(f.read().strip())
+        os.kill(pid, 0)
+        out['running'] = True
+    except (ProcessLookupError, ValueError):
+        return out
+    if os.path.exists(TRADER_LOG):
+        with open(TRADER_LOG) as f:
+            lines = f.readlines()
+        out['lines'] = [l.rstrip() for l in lines[-20:]]
+        out['trades'] = sum(1 for l in lines if ' TRADE: ' in l)
+    return out
+
+
+def parse_log(cfg):
+    log_path = cfg.get('log_file', '/tmp/arb_bot.log')
+    if not os.path.exists(log_path):
+        return {'running': False, 'lines': []}
+
+    with open(log_path) as f:
+        lines = f.readlines()
+
+    # Keep last 30 lines for display
+    recent = [l.rstrip() for l in lines[-30:]]
+
+    # Parse stats from the latest STATS line
+    stats = {
+        'iterations': 0,
+        'opportunities': 0,
+        'successes': 0,
+        'failures': 0,
+        'profit_weth': 0,
+        'gas_used': 0,
+        'elapsed_s': 0,
+        'last_opportunity': None,
+        'last_success': None,
+        'last_success_profit': 0,
+        'last_success_tx': None,
+    }
+
+    stats_re = re.compile(
+        r'STATS: iter=(\d+) opps=(\d+) ok=(\d+) fail=(\d+) profit=([\d.]+) WETH gas=(\d+) elapsed=(\d+)'
+    )
+    success_re = re.compile(
+        r'(\S+Z) SUCCESS: tx=(\S+) gas=(\d+) profit=([\d.]+) WETH \(\$([\d.]+)\)'
+    )
+    opp_re = re.compile(r'(\S+Z) OPPORTUNITY: dir=(\S+) amount=([\d.]+) WETH expected_profit=([\d.]+) USD')
+    heartbeat_re = re.compile(
+        r'(\S+Z) \[(\d+)\] L1=([\d.]+) L2=([\d.]+) spread=([+-][\d.]+)% best=([+-][\d.]+) USD \((\S+)\)'
+    )
+
+    for line in lines:
+        m = stats_re.search(line)
+        if m:
+            stats['iterations'] = int(m.group(1))
+            stats['opportunities'] = int(m.group(2))
+            stats['successes'] = int(m.group(3))
+            stats['failures'] = int(m.group(4))
+            stats['profit_weth'] = float(m.group(5))
+            stats['gas_used'] = int(m.group(6))
+            stats['elapsed_s'] = int(m.group(7))
+
+        m = success_re.search(line)
+        if m:
+            stats['last_success'] = m.group(1)
+            stats['last_success_tx'] = m.group(2)
+            stats['last_success_profit'] = float(m.group(5))
+
+        m = opp_re.search(line)
+        if m:
+            stats['last_opportunity'] = m.group(1)
+
+        m = heartbeat_re.search(line)
+        if m:
+            stats['last_heartbeat'] = m.group(1)
+            stats['last_heartbeat_iter'] = int(m.group(2))
+            stats['current_best_usd'] = float(m.group(6))
+            stats['current_best_dir'] = m.group(7)
+
+    heartbeat_file = cfg.get('heartbeat_file', '/tmp/arb_bot_heartbeat.log')
+    if os.path.exists(heartbeat_file):
+        with open(heartbeat_file) as f:
+            hb_line = f.read().strip()
+        m = heartbeat_re.search(hb_line)
+        if m:
+            stats['last_heartbeat'] = m.group(1)
+            stats['last_heartbeat_iter'] = int(m.group(2))
+            stats['current_best_usd'] = float(m.group(6))
+            stats['current_best_dir'] = m.group(7)
+
+    stats['lines'] = recent
+    pid_file = cfg.get('pid_file', '/tmp/arb_bot.pid')
+    if os.path.exists(pid_file):
+        try:
+            with open(pid_file) as f:
+                pid = int(f.read().strip())
+            os.kill(pid, 0)
+            stats['running'] = True
+        except (ProcessLookupError, ValueError):
+            stats['running'] = False
+    else:
+        stats['running'] = False
+    return stats
+
+
+HTML = r"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Cross-Chain Arb Dashboard</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; background: #0a0a0a; color: #e0e0e0; margin: 0; padding: 20px; }
+  h1 { margin: 0 0 20px; font-size: 20px; color: #6cf; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; margin-bottom: 16px; }
+  .card { background: #151515; border: 1px solid #2a2a2a; border-radius: 8px; padding: 16px; }
+  .card h2 { margin: 0 0 12px; font-size: 13px; color: #888; text-transform: uppercase; letter-spacing: 0.05em; }
+  .big { font-size: 28px; font-weight: 600; color: #fff; }
+  .sub { color: #888; font-size: 12px; margin-top: 4px; }
+  .pos { color: #4ade80; }
+  .neg { color: #f87171; }
+  .muted { color: #666; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  table td { padding: 4px 8px; border-bottom: 1px solid #1f1f1f; }
+  table td:first-child { color: #888; }
+  table td:last-child { text-align: right; font-family: ui-monospace, monospace; color: #fff; }
+  .log { background: #0a0a0a; border: 1px solid #2a2a2a; border-radius: 8px; padding: 12px; font-family: ui-monospace, monospace; font-size: 11px; line-height: 1.5; max-height: 420px; overflow-y: auto; }
+  .log-opp { color: #fbbf24; }
+  .log-ok { color: #4ade80; }
+  .log-err { color: #f87171; }
+  .log-stat { color: #6cf; }
+  .log-ts { color: #555; }
+  .status { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+  .status-ok { background: #4ade80; box-shadow: 0 0 6px #4ade80; }
+  .status-bad { background: #f87171; }
+  .spread-bar { height: 6px; background: #1f1f1f; border-radius: 3px; overflow: hidden; margin-top: 8px; }
+  .spread-fill { height: 100%; background: linear-gradient(90deg, #4ade80, #fbbf24, #f87171); }
+  .muted-addr { font-family: ui-monospace, monospace; font-size: 10px; color: #555; }
+</style>
+</head>
+<body>
+
+<h1>◆ Cross-Chain Arb Dashboard</h1>
+
+<div class="grid">
+  <div class="card">
+    <h2>L1 AMM</h2>
+    <div class="big" id="l1-price">—</div>
+    <div class="sub">USDC / WETH</div>
+    <table style="margin-top: 12px">
+      <tr><td>WETH</td><td id="l1-weth">—</td></tr>
+      <tr><td>USDC</td><td id="l1-usdc">—</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>L2 AMM</h2>
+    <div class="big" id="l2-price">—</div>
+    <div class="sub">USDC / WETH</div>
+    <table style="margin-top: 12px">
+      <tr><td>WETH</td><td id="l2-weth">—</td></tr>
+      <tr><td>USDC</td><td id="l2-usdc">—</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Spread</h2>
+    <div class="big" id="spread">—</div>
+    <div class="sub" id="spread-dir">—</div>
+    <div class="spread-bar" style="margin-top: 16px"><div class="spread-fill" id="spread-bar" style="width: 0%"></div></div>
+  </div>
+</div>
+
+<div class="grid" id="bots-grid"></div>
+
+<div class="grid" style="grid-template-columns: 1fr 1fr">
+  <div class="card">
+    <h2>Bot 1 Log</h2>
+    <div class="log" id="log-bot1">loading…</div>
+  </div>
+  <div class="card">
+    <h2>Bot 2 Log</h2>
+    <div class="log" id="log-bot2">loading…</div>
+  </div>
+</div>
+
+<div class="card">
+  <h2>Trader <span id="trader-state" style="font-size: 11px; margin-left: 10px"></span></h2>
+  <div class="log" id="log-trader" style="max-height: 200px">loading…</div>
+</div>
+
+<script>
+function fmt(n, dp) {
+  if (n === null || n === undefined) return '—';
+  return n.toLocaleString('en-US', {minimumFractionDigits: dp, maximumFractionDigits: dp});
+}
+
+function fmtElapsed(s) {
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (h) return `${h}h ${m}m`;
+  if (m) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
+
+function colorizeLog(line) {
+  const m = line.match(/^(\S+Z) (.*)$/);
+  if (!m) return line;
+  const ts = m[1], rest = m[2];
+  let cls = '';
+  if (rest.startsWith('OPPORTUNITY')) cls = 'log-opp';
+  else if (rest.startsWith('SUCCESS')) cls = 'log-ok';
+  else if (rest.startsWith('TRADE:')) cls = 'log-opp';
+  else if (rest.startsWith('ERROR') || rest.startsWith('REVERTED') || rest.startsWith('SEND ERROR') || rest.startsWith('skip')) cls = 'log-err';
+  else if (rest.startsWith('STATS')) cls = 'log-stat';
+  return `<span class="log-ts">${ts}</span> <span class="${cls}">${rest.replace(/</g, '&lt;')}</span>`;
+}
+
+async function refresh() {
+  try {
+    const r = await fetch('/api/state');
+    const s = await r.json();
+
+    document.getElementById('l1-price').textContent = fmt(s.l1.price, 2);
+    document.getElementById('l1-weth').textContent = fmt(s.l1.weth, 4);
+    document.getElementById('l1-usdc').textContent = fmt(s.l1.usdc, 2);
+
+    document.getElementById('l2-price').textContent = fmt(s.l2.price, 2);
+    document.getElementById('l2-weth').textContent = fmt(s.l2.weth, 4);
+    document.getElementById('l2-usdc').textContent = fmt(s.l2.usdc, 2);
+
+    const spread = s.spread_pct;
+    const spreadEl = document.getElementById('spread');
+    spreadEl.textContent = (spread >= 0 ? '+' : '') + spread.toFixed(3) + '%';
+    spreadEl.className = 'big ' + (Math.abs(spread) > 0.5 ? 'pos' : 'muted');
+    document.getElementById('spread-dir').textContent =
+      Math.abs(spread) < 0.05 ? 'balanced' :
+      spread > 0 ? 'L1 expensive, L2 cheap' : 'L2 expensive, L1 cheap';
+    document.getElementById('spread-bar').style.width = Math.min(100, Math.abs(spread) * 20) + '%';
+
+    // Render bots
+    const bots = s.bots || [];
+    const midPrice = (s.l1.price + s.l2.price) / 2;
+    const grid = document.getElementById('bots-grid');
+    grid.innerHTML = '';
+    grid.style.gridTemplateColumns = `repeat(${bots.length}, 1fr)`;
+
+    bots.forEach((b, i) => {
+      const running = b.running;
+      const currentBest = b.current_best_usd || 0;
+      const stateText = !running ? 'STOPPED'
+        : currentBest >= 1 ? 'FIRING' : 'MONITORING';
+      const verdict = !running ? 'bot process not found'
+        : currentBest >= 1 ? `will fire: ${b.current_best_dir || '?'} direction`
+        : currentBest > 0 ? `best: +$${currentBest.toFixed(2)} (< $1 threshold)`
+        : `no arb (fees ~0.6%, spread ${Math.abs(s.spread_pct).toFixed(2)}%)`;
+      const profitWeth = b.profit_weth || 0;
+      const profitUsd = profitWeth * midPrice;
+
+      const card = document.createElement('div');
+      card.className = 'card';
+      card.innerHTML = `
+        <h2>${b.name.toUpperCase()} <span style="float:right"><span class="status ${running ? 'status-ok' : 'status-bad'}"></span>${stateText}</span></h2>
+        <div class="big ${profitWeth > 0 ? 'pos' : ''}">${profitWeth >= 0 ? '+' : ''}${fmt(profitWeth, 6)} WETH</div>
+        <div class="sub">≈ $${fmt(profitUsd, 2)} · ${verdict}</div>
+        <table style="margin-top: 12px">
+          <tr><td>Capital</td><td>${fmt(b.weth_balance, 6)} WETH</td></tr>
+          <tr><td>Current best</td><td class="${currentBest >= 1 ? 'pos' : ''}">${currentBest > 0 ? '+$' + currentBest.toFixed(2) + ' (' + (b.current_best_dir || '?') + ')' : '$0.00'}</td></tr>
+          <tr><td>Successes</td><td>${fmt(b.successes || 0, 0)}</td></tr>
+          <tr><td>Failures</td><td class="${(b.failures||0)>0?'neg':''}">${fmt(b.failures || 0, 0)}</td></tr>
+          <tr><td>Iterations</td><td>${fmt(b.iterations || 0, 0)}</td></tr>
+          <tr><td>Gas spent</td><td>${fmt(b.gas_used || 0, 0)}</td></tr>
+          <tr><td>Elapsed</td><td>${fmtElapsed(b.elapsed_s || 0)}</td></tr>
+          <tr><td>Contract</td><td><span class="muted-addr">${b.address}</span></td></tr>
+        </table>
+      `;
+      grid.appendChild(card);
+    });
+
+    // Render bot logs
+    bots.forEach((b, i) => {
+      const el = document.getElementById(`log-${b.name}`);
+      if (el) el.innerHTML = (b.lines || []).map(colorizeLog).reverse().join('<br>');
+    });
+
+    // Render trader
+    const trader = s.trader || {};
+    const tEl = document.getElementById('trader-state');
+    if (tEl) {
+      tEl.innerHTML = `<span class="status ${trader.running ? 'status-ok' : 'status-bad'}"></span>${trader.running ? 'RUNNING' : 'STOPPED'} · ${trader.trades || 0} trades`;
+    }
+    const tLog = document.getElementById('log-trader');
+    if (tLog) tLog.innerHTML = (trader.lines || []).map(colorizeLog).reverse().join('<br>');
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+refresh();
+setInterval(refresh, 3000);
+</script>
+
+</body>
+</html>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass  # silence default access log
+
+    def do_GET(self):
+        if self.path == '/' or self.path.startswith('/?'):
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html; charset=utf-8')
+            self.end_headers()
+            self.wfile.write(HTML.encode('utf-8'))
+        elif self.path == '/api/state':
+            try:
+                data = get_state()
+                body = json.dumps(data).encode('utf-8')
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.send_header('Access-Control-Allow-Origin', '*')
+                self.end_headers()
+                self.wfile.write(body)
+            except Exception as e:
+                self.send_response(500)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({'error': str(e)}).encode('utf-8'))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def main():
+    print(f'Dashboard: http://localhost:{PORT}/')
+    HTTPServer(('0.0.0.0', PORT), Handler).serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/deploy_arb_eez.sh
+++ b/scripts/deploy_arb_eez.sh
@@ -22,9 +22,16 @@ BRIDGE="0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
 BRIDGE_L2="0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
 ROLLUP_ID=1
 
-# Funder = anvil dev#0 (always genesis-funded on this dev chain)
-FUNDER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-FUNDER="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+# Funder — DO NOT use dev#0 (0xf39F…): that is the builder / deployer key.
+# Using it for deploy txs collides with the builder's own nonces and halts L2.
+# Default to dev#9 (0xa0Ee…), the "L1 funder" role per composer-pr/CLAUDE.md.
+# Override via FUNDER_KEY env var if you need a different account.
+FUNDER_KEY="${FUNDER_KEY:-0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6}"
+FUNDER="$(cast wallet address --private-key "$FUNDER_KEY")"
+if [ "${FUNDER,,}" = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266" ]; then
+    printf '\033[0;31mREFUSING to run with dev#0 (builder key) as FUNDER — this halts L2.\033[0m\n' >&2
+    exit 1
+fi
 
 # Bot operators (arb contract owners)
 BOT1_KEY="0x4fff4c1f39910ff9722e4257a8ae58f92b93b5e31ecad4c74d0628b97ec793d3"

--- a/scripts/deploy_arb_eez.sh
+++ b/scripts/deploy_arb_eez.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Deploy the full cross-chain arb stack on EEZ:
+#   - L1 MockERC20 WETH + USDC
+#   - L1 SimpleAMM seeded with WETH/USDC
+#   - Bridge wraps to discover L2 token addresses
+#   - L2 SimpleAMM seeded with bridged WETH/USDC
+#   - L2Executor + cross-chain proxy on L1
+#   - Two CrossChainArb contracts (one per bot operator)
+#   - Funds bot operators with ETH and seeds working WETH capital
+#   - Writes /tmp/arb_config.json and /tmp/arb_config_2.json
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTRACTS_DIR="$(cd "$SCRIPT_DIR/../contracts/test-multi-call" && pwd)"
+
+L1_RPC="${L1_RPC:-http://eez.dev:9556}"
+L1_PROXY="${L1_PROXY:-https://eez.dev/composer/l1-proxy}"
+L2_RPC="${L2_RPC:-https://eez.dev/composer/l2}"
+
+ROLLUPS="0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+BRIDGE="0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+BRIDGE_L2="0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+ROLLUP_ID=1
+
+# Funder = anvil dev#0 (always genesis-funded on this dev chain)
+FUNDER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+FUNDER="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+# Bot operators (arb contract owners)
+BOT1_KEY="0x4fff4c1f39910ff9722e4257a8ae58f92b93b5e31ecad4c74d0628b97ec793d3"
+BOT1="0xCC563C3F7d49bAC23725Ec5aC2B269747e4Cd491"
+BOT2_KEY="0xeaa861a9a01391ed3d587d8a5a84ca56ee277629a8b02c22093a419bf240e65d"
+BOT2="0x09DB0a93B389bEF724429898f539AEB7ac2Dd55f"
+
+CO="--legacy --gas-price 1000000000"
+CO_LONG="--legacy --gas-price 1000000000 --timeout 300"
+
+# Liquidity sizing (string literals — bash arithmetic overflows int64 above 9.2e18)
+LIQ_WETH="100000000000000000000"     # 100 WETH (1e20)
+LIQ_USDC="300000000000"              # 300k USDC (3e11)
+ARB_CAPITAL="1000000000000000000"    # 1 WETH (1e18)
+DEV_FUND_ETH="10000000000000000000"  # 10 ETH (1e19)
+# Funder mint: 4*LIQ_WETH (covers L1 liq + L2 bridge + arb capital + headroom)
+MINT_WETH="400000000000000000000"    # 400 WETH
+MINT_USDC="900000000000"             # 900k USDC
+
+blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[0;31m%s\033[0m\n' "$*"; }
+
+fcreate() {
+    local rpc="$1" key="$2" contract="$3"; shift 3
+    forge create $CO --rpc-url "$rpc" --private-key "$key" --broadcast \
+        --root "$CONTRACTS_DIR" "$contract" "$@" 2>&1 \
+        | grep "Deployed to:" | awk '{print $3}'
+}
+
+send() {
+    # send <rpc> <key> <to> <sig> <args...>
+    local rpc="$1" key="$2" to="$3" sig="$4"; shift 4
+    cast send $CO --rpc-url "$rpc" --private-key "$key" "$to" "$sig" "$@" \
+        --gas-limit 1500000 > /dev/null
+}
+
+blue "=== Compile ==="
+(cd "$CONTRACTS_DIR" && forge build > /dev/null 2>&1) || { red "compile failed"; exit 1; }
+green "  ok"
+
+blue "=== Fund bot operators ==="
+for op in "$BOT1" "$BOT2"; do
+    cast send $CO --rpc-url "$L1_RPC" --private-key "$FUNDER_KEY" \
+        --value "$DEV_FUND_ETH" "$op" --gas-limit 50000 > /dev/null
+    green "  $op funded on L1"
+done
+
+blue "=== Deploy L1 tokens ==="
+WETH_L1=$(fcreate "$L1_RPC" "$FUNDER_KEY" "src/MockERC20.sol:MockERC20" \
+    --constructor-args "Wrapped Ether" "WETH" 18)
+USDC_L1=$(fcreate "$L1_RPC" "$FUNDER_KEY" "src/MockERC20.sol:MockERC20" \
+    --constructor-args "USD Coin" "USDC" 6)
+[ -n "$WETH_L1" ] && [ -n "$USDC_L1" ] || { red "token deploy failed"; exit 1; }
+green "  WETH_L1: $WETH_L1"
+green "  USDC_L1: $USDC_L1"
+
+blue "=== Mint L1 tokens to funder ==="
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "mint(address,uint256)" "$FUNDER" "$MINT_WETH"
+send "$L1_RPC" "$FUNDER_KEY" "$USDC_L1" "mint(address,uint256)" "$FUNDER" "$MINT_USDC"
+green "  minted"
+
+blue "=== Deploy L1 SimpleAMM and add liquidity ==="
+AMM_L1=$(fcreate "$L1_RPC" "$FUNDER_KEY" "src/SimpleAMM.sol:SimpleAMM" \
+    --constructor-args "$WETH_L1" "$USDC_L1")
+[ -n "$AMM_L1" ] || { red "AMM_L1 deploy failed"; exit 1; }
+green "  AMM_L1: $AMM_L1"
+
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "approve(address,uint256)" "$AMM_L1" "$LIQ_WETH"
+send "$L1_RPC" "$FUNDER_KEY" "$USDC_L1" "approve(address,uint256)" "$AMM_L1" "$LIQ_USDC"
+send "$L1_RPC" "$FUNDER_KEY" "$AMM_L1" "addLiquidity(uint256,uint256)" "$LIQ_WETH" "$LIQ_USDC"
+green "  L1 liquidity added: 100 WETH / 300k USDC"
+
+blue "=== Bridge WETH and USDC to L2 (seed L2 AMM) ==="
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "approve(address,uint256)" "$BRIDGE" "$LIQ_WETH"
+send "$L1_RPC" "$FUNDER_KEY" "$USDC_L1" "approve(address,uint256)" "$BRIDGE" "$LIQ_USDC"
+cast send $CO_LONG --rpc-url "$L1_PROXY" --private-key "$FUNDER_KEY" "$BRIDGE" \
+    "bridgeTokens(address,uint256,uint256,address)" "$WETH_L1" "$LIQ_WETH" "$ROLLUP_ID" "$FUNDER" \
+    --gas-limit 1500000 > /dev/null
+cast send $CO_LONG --rpc-url "$L1_PROXY" --private-key "$FUNDER_KEY" "$BRIDGE" \
+    "bridgeTokens(address,uint256,uint256,address)" "$USDC_L1" "$LIQ_USDC" "$ROLLUP_ID" "$FUNDER" \
+    --gas-limit 1500000 > /dev/null
+green "  bridge txs sent"
+
+blue "=== Discover L2 wrapped token addresses ==="
+WETH_L2=""
+USDC_L2=""
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 3
+    WETH_L2=$(cast call --rpc-url "$L2_RPC" "$BRIDGE_L2" \
+        "getWrappedToken(address,uint256)(address)" "$WETH_L1" 0 2>/dev/null || true)
+    USDC_L2=$(cast call --rpc-url "$L2_RPC" "$BRIDGE_L2" \
+        "getWrappedToken(address,uint256)(address)" "$USDC_L1" 0 2>/dev/null || true)
+    if [ -n "$WETH_L2" ] && [ -n "$USDC_L2" ] \
+       && [ "$WETH_L2" != "0x0000000000000000000000000000000000000000" ] \
+       && [ "$USDC_L2" != "0x0000000000000000000000000000000000000000" ]; then
+        # also wait for funder balance
+        wbal=$(cast call --rpc-url "$L2_RPC" "$WETH_L2" "balanceOf(address)(uint256)" "$FUNDER" 2>/dev/null | awk '{print $1}')
+        ubal=$(cast call --rpc-url "$L2_RPC" "$USDC_L2" "balanceOf(address)(uint256)" "$FUNDER" 2>/dev/null | awk '{print $1}')
+        if [ "${wbal:-0}" -ge "$LIQ_WETH" ] 2>/dev/null && [ "${ubal:-0}" -ge "$LIQ_USDC" ] 2>/dev/null; then
+            break
+        fi
+    fi
+    blue "  waiting for bridge delivery... ($i)"
+done
+[ -n "$WETH_L2" ] && [ "$WETH_L2" != "0x0000000000000000000000000000000000000000" ] || { red "WETH_L2 not found"; exit 1; }
+[ -n "$USDC_L2" ] && [ "$USDC_L2" != "0x0000000000000000000000000000000000000000" ] || { red "USDC_L2 not found"; exit 1; }
+green "  WETH_L2: $WETH_L2"
+green "  USDC_L2: $USDC_L2"
+
+blue "=== Deploy L2 SimpleAMM and add liquidity ==="
+AMM_L2=$(fcreate "$L2_RPC" "$FUNDER_KEY" "src/SimpleAMM.sol:SimpleAMM" \
+    --constructor-args "$WETH_L2" "$USDC_L2")
+[ -n "$AMM_L2" ] || { red "AMM_L2 deploy failed"; exit 1; }
+green "  AMM_L2: $AMM_L2"
+
+send "$L2_RPC" "$FUNDER_KEY" "$WETH_L2" "approve(address,uint256)" "$AMM_L2" "$LIQ_WETH"
+send "$L2_RPC" "$FUNDER_KEY" "$USDC_L2" "approve(address,uint256)" "$AMM_L2" "$LIQ_USDC"
+send "$L2_RPC" "$FUNDER_KEY" "$AMM_L2" "addLiquidity(uint256,uint256)" "$LIQ_WETH" "$LIQ_USDC"
+green "  L2 liquidity added"
+
+blue "=== Deploy L2Executor on L2 ==="
+L2_EXEC=$(fcreate "$L2_RPC" "$FUNDER_KEY" "src/L2Executor.sol:L2Executor" \
+    --constructor-args "$AMM_L2" "$BRIDGE_L2" "$WETH_L2" "$USDC_L2")
+[ -n "$L2_EXEC" ] || { red "L2Executor deploy failed"; exit 1; }
+green "  L2_EXEC: $L2_EXEC"
+
+blue "=== Create cross-chain proxy for L2Executor on L1 ==="
+send "$L1_RPC" "$FUNDER_KEY" "$ROLLUPS" "createCrossChainProxy(address,uint256)" "$L2_EXEC" "$ROLLUP_ID"
+L2_EXEC_PROXY=$(cast call --rpc-url "$L1_RPC" "$ROLLUPS" \
+    "computeCrossChainProxyAddress(address,uint256)(address)" "$L2_EXEC" "$ROLLUP_ID" 2>/dev/null)
+green "  L2_EXEC_PROXY: $L2_EXEC_PROXY"
+
+blue "=== Deploy CrossChainArb #1 (Bot1) ==="
+ARB1=$(fcreate "$L1_RPC" "$BOT1_KEY" "src/CrossChainArb.sol:CrossChainArb" \
+    --constructor-args "$WETH_L1" "$USDC_L1" "$AMM_L1" "$BRIDGE" "$ROLLUP_ID")
+[ -n "$ARB1" ] || { red "ARB1 deploy failed"; exit 1; }
+send "$L1_RPC" "$BOT1_KEY" "$ARB1" "setL2Executor(address,address)" "$L2_EXEC" "$L2_EXEC_PROXY"
+green "  ARB1: $ARB1"
+
+blue "=== Deploy CrossChainArb #2 (Bot2) ==="
+ARB2=$(fcreate "$L1_RPC" "$BOT2_KEY" "src/CrossChainArb.sol:CrossChainArb" \
+    --constructor-args "$WETH_L1" "$USDC_L1" "$AMM_L1" "$BRIDGE" "$ROLLUP_ID")
+[ -n "$ARB2" ] || { red "ARB2 deploy failed"; exit 1; }
+send "$L1_RPC" "$BOT2_KEY" "$ARB2" "setL2Executor(address,address)" "$L2_EXEC" "$L2_EXEC_PROXY"
+green "  ARB2: $ARB2"
+
+blue "=== Fund arb contracts with WETH working capital ==="
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "mint(address,uint256)" "$ARB1" "$ARB_CAPITAL"
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "mint(address,uint256)" "$ARB2" "$ARB_CAPITAL"
+green "  each arb funded with 1 WETH"
+
+blue "=== Write configs ==="
+write_cfg() {
+    local path="$1" name="$2" key="$3" addr="$4" arb="$5" log="$6" hb="$7" pid="$8"
+    cat > "$path" <<EOF
+{
+  "l1_rpc": "$L1_RPC",
+  "l1_proxy": "$L1_PROXY",
+  "l2_rpc": "$L2_RPC",
+  "weth_l1": "$WETH_L1",
+  "usdc_l1": "$USDC_L1",
+  "amm_l1": "$AMM_L1",
+  "weth_l2": "$WETH_L2",
+  "usdc_l2": "$USDC_L2",
+  "amm_l2": "$AMM_L2",
+  "bridge": "$BRIDGE",
+  "l2_executor": "$L2_EXEC",
+  "l2_executor_proxy": "$L2_EXEC_PROXY",
+  "bot_name": "$name",
+  "test_key": "$key",
+  "test_addr": "$addr",
+  "arb_contract": "$arb",
+  "log_file": "$log",
+  "heartbeat_file": "$hb",
+  "pid_file": "$pid"
+}
+EOF
+}
+write_cfg /tmp/arb_config.json   bot1 "$BOT1_KEY" "$BOT1" "$ARB1" /tmp/arb_bot.log  /tmp/arb_bot_heartbeat.log  /tmp/arb_bot.pid
+write_cfg /tmp/arb_config_2.json bot2 "$BOT2_KEY" "$BOT2" "$ARB2" /tmp/arb_bot2.log /tmp/arb_bot2_heartbeat.log /tmp/arb_bot2.pid
+green "  /tmp/arb_config.json"
+green "  /tmp/arb_config_2.json"
+
+green ""
+green "=== Deploy complete ==="
+echo "ARB1=$ARB1"
+echo "ARB2=$ARB2"
+echo "AMM_L1=$AMM_L1  AMM_L2=$AMM_L2"
+echo "L2_EXEC=$L2_EXEC  proxy=$L2_EXEC_PROXY"

--- a/scripts/deploy_arb_eez.sh
+++ b/scripts/deploy_arb_eez.sh
@@ -19,7 +19,16 @@ L2_RPC="${L2_RPC:-https://eez.dev/composer/l2}"
 
 ROLLUPS="0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
 BRIDGE="0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
-BRIDGE_L2="0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+# BRIDGE_L2 is deployed at L2 genesis as the 3rd contract (nonce 2).
+# Auto-discover from block 1 so this script survives chain resets.
+BRIDGE_L2="${BRIDGE_L2:-$(python3 -c "
+import json, urllib.request
+req = urllib.request.Request('$L2_RPC', data=json.dumps({'jsonrpc':'2.0','method':'eth_getBlockByNumber','params':['0x1', True],'id':1}).encode(), headers={'Content-Type':'application/json'})
+blk = json.loads(urllib.request.urlopen(req).read())['result']
+tx = next(t for t in blk['transactions'] if int(t['nonce'],16)==2)
+r = urllib.request.Request('$L2_RPC', data=json.dumps({'jsonrpc':'2.0','method':'eth_getTransactionReceipt','params':[tx['hash']],'id':1}).encode(), headers={'Content-Type':'application/json'})
+print(json.loads(urllib.request.urlopen(r).read())['result']['contractAddress'])
+")}"
 ROLLUP_ID=1
 
 # Funder — DO NOT use dev#0 (0xf39F…): that is the builder / deployer key.

--- a/scripts/trader.py
+++ b/scripts/trader.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Random trader that creates price movements on L1 or L2 AMM.
+
+Each iteration:
+- Picks random pool (L1 or L2)
+- Picks random direction (buy WETH with USDC, or sell WETH for USDC)
+- Picks random target price move (0.5% – 5%)
+- Computes trade size to achieve that move
+- Executes the swap
+- Sleeps random 5–20s
+
+Uses dev#9 key. Has funds on both L1 and L2.
+"""
+
+import json
+import time
+import random
+import math
+from datetime import datetime, timezone
+from web3 import Web3
+from eth_account import Account
+
+# Reuse addresses from bot config
+with open('/tmp/arb_config.json') as f:
+    CFG = json.load(f)
+
+for k in ['weth_l1', 'usdc_l1', 'amm_l1', 'amm_l2', 'weth_l2', 'usdc_l2']:
+    CFG[k] = Web3.to_checksum_address(CFG[k])
+
+TRADER_KEY = '0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6'  # dev#9
+TRADER = Account.from_key(TRADER_KEY)
+
+w3_l1 = Web3(Web3.HTTPProvider(CFG['l1_rpc']))
+w3_l2 = Web3(Web3.HTTPProvider(CFG['l2_rpc']))
+
+FEE_NUM = 997
+FEE_DEN = 1000
+LOG = '/tmp/trader.log'
+PID_FILE = '/tmp/trader.pid'
+
+AMM_ABI = [
+    {"inputs": [], "name": "reserveA", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "reserveB", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [{"type": "address"}, {"type": "uint256"}], "name": "swap", "outputs": [{"type": "uint256"}], "stateMutability": "nonpayable", "type": "function"},
+]
+ERC20_ABI = [
+    {"inputs": [{"type": "address"}], "name": "balanceOf", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [{"type": "address"}, {"type": "uint256"}], "name": "approve", "outputs": [{"type": "bool"}], "stateMutability": "nonpayable", "type": "function"},
+    {"inputs": [{"type": "address"}, {"type": "uint256"}], "name": "mint", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
+]
+
+
+def log(msg):
+    ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    line = f'{ts} {msg}'
+    print(line, flush=True)
+    with open(LOG, 'a') as f:
+        f.write(line + '\n')
+
+
+def trade_size_for_price_move(reserve_in, pct):
+    """
+    Given target price move fraction `pct` (e.g. 0.03 for 3%) on a CP AMM,
+    compute input amount (of tokenIn) needed.
+
+    Selling tokenIn for tokenOut moves tokenOut/tokenIn price DOWN.
+    For target price ratio k = new/old, a = reserve_in * (1/sqrt(k) - 1).
+
+    For selling tokenA with target price-down move of `pct`:
+      k = 1 - pct
+      a = reserve_in * (1/sqrt(1-pct) - 1)
+
+    (Ignores 0.3% fee — close enough for 0.5-5% targets.)
+    """
+    k = 1 - pct
+    return int(reserve_in * (1 / math.sqrt(k) - 1))
+
+
+def _mint_token(w3, token_addr, amount_needed, label):
+    """Mint amount_needed (+headroom) of a MockERC20 token to the trader."""
+    erc = w3.eth.contract(address=token_addr, abi=ERC20_ABI)
+    bal = erc.functions.balanceOf(TRADER.address).call()
+    if bal >= amount_needed:
+        return True
+    deficit = amount_needed - bal
+    # Mint 10x the needed amount so we don't have to keep topping up
+    to_mint = deficit * 10
+    tx = erc.functions.mint(TRADER.address, to_mint).build_transaction({
+        'from': TRADER.address,
+        'nonce': w3.eth.get_transaction_count(TRADER.address),
+        'gas': 200000,
+        'gasPrice': 2 * 10**9,
+        'chainId': w3.eth.chain_id,
+    })
+    signed = TRADER.sign_transaction(tx)
+    try:
+        receipt = w3.eth.wait_for_transaction_receipt(
+            w3.eth.send_raw_transaction(signed.raw_transaction), timeout=60)
+        if receipt['status'] == 1:
+            log(f'minted {to_mint / (10**6 if "USDC" in label else 10**18):.2f} {label}')
+            return True
+        else:
+            log(f'mint {label} reverted')
+            return False
+    except Exception as e:
+        log(f'mint {label} error: {e}')
+        return False
+
+
+def ensure_weth_on_l1(amt):
+    return _mint_token(w3_l1, CFG['weth_l1'], amt, 'L1 WETH')
+
+
+def ensure_usdc_on_l1(amt):
+    return _mint_token(w3_l1, CFG['usdc_l1'], amt, 'L1 USDC')
+
+
+def ensure_weth_on_l2(amt):
+    """L2 WETH is a bridge-wrapped token (WrappedToken.sol) — no public mint."""
+    weth = w3_l2.eth.contract(address=CFG['weth_l2'], abi=ERC20_ABI)
+    return weth.functions.balanceOf(TRADER.address).call() >= amt
+
+
+def ensure_usdc_on_l2(amt):
+    """Same — L2 USDC is bridge-wrapped, no public mint."""
+    usdc = w3_l2.eth.contract(address=CFG['usdc_l2'], abi=ERC20_ABI)
+    return usdc.functions.balanceOf(TRADER.address).call() >= amt
+
+
+def do_trade(chain, sell_weth, pct_target):
+    """
+    chain: 'l1' or 'l2'
+    sell_weth: True = sell WETH for USDC (price down). False = sell USDC (price up).
+    pct_target: fraction in [0.005, 0.05]
+    """
+    if chain == 'l1':
+        w3 = w3_l1
+        amm_addr = CFG['amm_l1']
+        weth_addr = CFG['weth_l1']
+        usdc_addr = CFG['usdc_l1']
+        rpc_url = CFG['l1_proxy']  # route through proxy so composer picks up if needed
+    else:
+        w3 = w3_l2
+        amm_addr = CFG['amm_l2']
+        weth_addr = CFG['weth_l2']
+        usdc_addr = CFG['usdc_l2']
+        rpc_url = CFG['l2_rpc']
+
+    amm = w3.eth.contract(address=amm_addr, abi=AMM_ABI)
+    ra = amm.functions.reserveA().call()  # WETH reserve
+    rb = amm.functions.reserveB().call()  # USDC reserve
+
+    if sell_weth:
+        token_in = weth_addr
+        amount_in = trade_size_for_price_move(ra, pct_target)
+        # Cap at fraction of reserve for sanity
+        amount_in = min(amount_in, ra // 3)
+    else:
+        token_in = usdc_addr
+        amount_in = trade_size_for_price_move(rb, pct_target)
+        amount_in = min(amount_in, rb // 3)
+
+    if amount_in == 0:
+        return False, 'zero amount'
+
+    # Ensure sufficient balance (mint on L1, skip on L2 where we can't mint)
+    erc = w3.eth.contract(address=token_in, abi=ERC20_ABI)
+    if chain == 'l1':
+        if sell_weth:
+            if not ensure_weth_on_l1(amount_in):
+                return False, 'mint L1 WETH failed'
+        else:
+            if not ensure_usdc_on_l1(amount_in):
+                return False, 'mint L1 USDC failed'
+    else:
+        # L2 — can't mint, must have received tokens from bridge
+        bal = erc.functions.balanceOf(TRADER.address).call()
+        if bal < amount_in:
+            return False, f'insufficient on L2 ({bal} < {amount_in})'
+
+    # Approve + swap (via proxy if L1 — composer is tolerant of plain swaps)
+    w3_send = Web3(Web3.HTTPProvider(rpc_url))
+
+    tx1 = erc.functions.approve(amm_addr, amount_in).build_transaction({
+        'from': TRADER.address,
+        'nonce': w3_send.eth.get_transaction_count(TRADER.address),
+        'gas': 100000,
+        'gasPrice': 2 * 10**9,
+        'chainId': w3_send.eth.chain_id,
+    })
+    signed = TRADER.sign_transaction(tx1)
+    w3.eth.wait_for_transaction_receipt(w3_send.eth.send_raw_transaction(signed.raw_transaction), timeout=60)
+
+    tx2 = amm.functions.swap(token_in, amount_in).build_transaction({
+        'from': TRADER.address,
+        'nonce': w3_send.eth.get_transaction_count(TRADER.address),
+        'gas': 500000,
+        'gasPrice': 2 * 10**9,
+        'chainId': w3_send.eth.chain_id,
+    })
+    signed = TRADER.sign_transaction(tx2)
+    tx_hash = w3_send.eth.send_raw_transaction(signed.raw_transaction)
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+    if receipt['status'] != 1:
+        return False, f'tx reverted: {tx_hash.hex()}'
+
+    # Report actual price move
+    ra2 = amm.functions.reserveA().call()
+    rb2 = amm.functions.reserveB().call()
+    p1 = rb / ra if ra else 0
+    p2 = rb2 / ra2 if ra2 else 0
+    actual_pct = (p2 - p1) / p1 * 100 if p1 else 0
+    return True, f'{chain} {"sellWETH" if sell_weth else "buyWETH"} in={amount_in} priceMove={actual_pct:+.2f}%'
+
+
+def main():
+    import os
+    with open(PID_FILE, 'w') as f:
+        f.write(str(os.getpid()))
+
+    log('=== TRADER START ===')
+    log(f'Address: {TRADER.address}')
+    log(f'L1 balance: {w3_l1.eth.get_balance(TRADER.address) / 1e18:.2f} ETH')
+    log(f'L2 balance: {w3_l2.eth.get_balance(TRADER.address) / 1e18:.2f} ETH')
+
+    # Bootstrap: mint initial WETH + USDC on L1 so we can trade either direction
+    ensure_weth_on_l1(100 * 10**18)
+    ensure_usdc_on_l1(200_000 * 10**6)
+    weth = w3_l1.eth.contract(address=CFG['weth_l1'], abi=ERC20_ABI)
+    usdc = w3_l1.eth.contract(address=CFG['usdc_l1'], abi=ERC20_ABI)
+    log(f'L1 WETH: {weth.functions.balanceOf(TRADER.address).call() / 1e18:.4f}')
+    log(f'L1 USDC: {usdc.functions.balanceOf(TRADER.address).call() / 1e6:.2f}')
+
+    while True:
+        try:
+            # Pick random parameters
+            chain = random.choice(['l1', 'l2'])
+            sell_weth = random.choice([True, False])
+            pct = random.uniform(0.005, 0.05)
+
+            ok, msg = do_trade(chain, sell_weth, pct)
+            if ok:
+                log(f'TRADE: {msg}')
+            else:
+                log(f'skip: {msg}')
+        except Exception as e:
+            log(f'ERROR: {e}')
+
+        time.sleep(random.uniform(5, 20))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Self-contained, idempotent reproducer for the concurrent cross-chain failure mode tracked in #29. Intended to validate PR #30 (`fix(derivation): apply §4f filtering to all blocks in multi-block batch`) end-to-end once it lands and EEZ is redeployed.

## What's included

- `contracts/test-multi-call/src/CrossChainArb.sol` — arb contract with `arbSellOnL1` / `arbSellOnL2` entry points, holds WETH as working capital.
- `scripts/deploy_arb_eez.sh` — one-shot deploy of the full stack:
  1. Funds two operator EOAs from dev#9 (NOT dev#0 — see note below)
  2. Deploys L1 MockERC20 WETH/USDC + SimpleAMM, seeds 100 WETH / 300k USDC
  3. Bridges to L2, waits for wrapping, deploys L2 SimpleAMM, seeds the same liquidity
  4. Deploys `L2Executor` on L2, creates its cross-chain proxy on L1
  5. Deploys two `CrossChainArb` instances (one per operator), each funded with 1 WETH
  6. Writes `/tmp/arb_config.json` and `/tmp/arb_config_2.json`
- `scripts/arb_bot.py` — the polling bot; reads config path from `argv[1]` so two instances can race side-by-side.
- `scripts/trader.py` — random L1/L2 trader to keep prices moving.
- `scripts/arb_dashboard.py` — live dashboard for both bots + trader.

## How to run

```bash
./scripts/deploy_arb_eez.sh
python3 scripts/arb_bot.py /tmp/arb_config.json   &
python3 scripts/arb_bot.py /tmp/arb_config_2.json &
python3 scripts/trader.py &
```

On a healthy chain (i.e. one where #29 / #30 is resolved), both bots should produce arb successes side-by-side instead of `ExecutionNotFound` / `ExecutionNotInCurrentBlock` reverts.

## Note on funder account

First revision of the script used dev#0 as the funder, which is the builder / deployer key on EEZ. That caused a nonce collision with the builder's own `postBatch` submissions and halted L2 on the testnet for 30+ minutes. Fixed in `979f5f5`:
- Default `FUNDER_KEY` is now dev#9 (`0xa0Ee…`), the "L1 funder" role per `CLAUDE.md`.
- Overridable via `FUNDER_KEY` env var.
- Script hard-refuses to run if the resolved funder is dev#0.

## Status

- Reproducer end-to-end is **not yet confirmed** on the current testnet because the prior dev#0 mishap stalled L2 before the full deploy could complete.
- Once PR #30 lands and EEZ is redeployed, this branch is ready to validate it.

Closes: (none — leaves #29 open as the tracking issue)
Related: #30

## Test plan

- [ ] Run `./scripts/deploy_arb_eez.sh` on a healthy EEZ with PR #30 merged — expect success through all steps
- [ ] Start both bots + trader; leave running for 1h
- [ ] Confirm `ExecutionNotFound` / `ExecutionNotInCurrentBlock` revert rate is negligible
- [ ] Confirm both bots record arb successes (non-zero profit rows in their logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)