### PR TITLE
fix(driver/rewind): write rewind target after rollback_to, not before

### DIFF
--- a/crates/based-rollup/src/derivation.rs
+++ b/crates/based-rollup/src/derivation.rs
@@ -898,7 +898,13 @@ impl DerivationPipeline {
         self.last_execution_l1_block = l1_block.min(self.last_execution_l1_block);
         self.builder_execution_l1_block = l1_block.min(self.builder_execution_l1_block);
         let last_valid_l2 = self.cursor.last().map(|m| m.l2_block_number);
-        // Reset L2 tracking for gap-fill to match the rollback point
+        // Reset L2 tracking for gap-fill to match the rollback point.
+        // When the cursor is empty (deep reorg, or size-cap eviction below
+        // the fork point), callers that need to preserve a
+        // deliberately-set `last_derived_l2_block` must set it AFTER
+        // calling this method — see `Driver::rewind_to_re_derive`. Callers
+        // that want the reset-to-genesis semantic (e.g., the L1 reorg path
+        // in driver/mod.rs) rely on this unconditional `unwrap_or(0)`.
         self.last_derived_l2_block = last_valid_l2.unwrap_or(0);
         // Restore last_l1_info from the last retained cursor entry so gap-fill
         // blocks after rollback use the correct L1 context instead of falling

--- a/crates/based-rollup/src/derivation_tests.rs
+++ b/crates/based-rollup/src/derivation_tests.rs
@@ -87,6 +87,42 @@ fn test_rollback_to_before_all_cursor_entries() {
     assert_eq!(pipeline.cursor_len(), 0);
 }
 
+/// Regression test for the `rewind_to_re_derive` ordering bug: after
+/// rolling back the cursor and then authoritatively setting the
+/// derivation head to the rewind target, the head must equal the
+/// target even when the cursor is empty. This mirrors the sequence in
+/// `driver/rewind.rs:rewind_to_re_derive` after the fix (rollback
+/// first, set second).
+#[test]
+fn test_rewind_sequence_leaves_derivation_head_at_target_when_cursor_empty() {
+    let config = test_config();
+    let mut pipeline = DerivationPipeline::new(config);
+
+    for i in 3371..=3400 {
+        pipeline.cursor.push(DerivedBlockMeta {
+            l2_block_number: i - 1000,
+            l1_block_number: i,
+            l1_block_hash: B256::with_last_byte(i as u8),
+        });
+    }
+    pipeline.last_processed_l1_block = 3400;
+    pipeline.set_last_derived_l2_block(3520);
+
+    let target_l2_block = 3483u64;
+    let rollback_l1_block = 3370u64;
+
+    // Exactly the call order used by `Driver::rewind_to_re_derive`.
+    pipeline.rollback_to(rollback_l1_block);
+    pipeline.set_last_derived_l2_block(target_l2_block);
+
+    assert_eq!(pipeline.cursor_len(), 0);
+    assert_eq!(
+        pipeline.last_derived_l2_block, target_l2_block,
+        "rewind_to_re_derive must leave last_derived_l2_block at the \
+         requested target (not 0 from the empty-cursor fallback)"
+    );
+}
+
 #[test]
 fn test_prune_finalized() {
     let config = test_config();

--- a/crates/based-rollup/src/driver/rewind.rs
+++ b/crates/based-rollup/src/driver/rewind.rs
@@ -96,8 +96,18 @@ where
     /// no rewind-cycle increment) and does not call this helper.
     pub(super) fn rewind_to_re_derive(&mut self, target_l2_block: u64, rollback_l1_block: u64) {
         self.clear_internal_state();
-        self.derivation.set_last_derived_l2_block(target_l2_block);
+        // Order matters. `rollback_to` sets `last_derived_l2_block` as a
+        // side-effect based on the cursor contents (`last_valid_l2.unwrap_or(0)`).
+        // When the cursor has been evicted below `rollback_l1_block` (size
+        // cap at derivation.rs:801), it resets the derivation head to 0 —
+        // which, combined with an L2 head far ahead of 0, wedges derivation
+        // via `MAX_BLOCK_GAP`. Call `rollback_to` FIRST so its side-effect
+        // runs, THEN authoritatively overwrite with the intended target.
+        // Regression: `test_rewind_sequence_leaves_derivation_head_at_target_when_cursor_empty`.
+        // Root-cause incident: testnet-eez 2026-04-16, 32 min of rewind
+        // cycles followed by a permanent `expected next block 1` wedge.
         self.derivation.rollback_to(rollback_l1_block);
+        self.derivation.set_last_derived_l2_block(target_l2_block);
         self.mode = DriverMode::Sync;
         self.synced
             .store(false, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
## Summary

- Fixes the testnet-eez wedge at L2 3483 / L1 3370 where the derivation pipeline got stuck emitting `BatchPosted block 3354 exceeds MAX_BLOCK_GAP (1000): expected next block 1, gap size 3353` every 60 s.
- Swaps the `set_last_derived_l2_block` / `rollback_to` calls in `Driver::rewind_to_re_derive` so the caller-supplied target is written **after** `rollback_to`'s cursor side-effect, not before it.
- Adds a regression test that reproduces the exact testnet-eez call sequence (`test_rewind_sequence_leaves_derivation_head_at_target_when_cursor_empty`).

## Root cause (byte-level verified)

`DerivationPipeline::rollback_to` unconditionally assigns `last_derived_l2_block = last_valid_l2.unwrap_or(0)`. When the cursor has been evicted below `rollback_l1_block` (size cap at `derivation.rs:801`, `> 2 * REORG_CHECK_DEPTH` → drain to 64), `last_valid_l2 = None` and the head is silently reset to 0 — clobbering the target that `rewind_to_re_derive` had just set one line earlier. With the L2 head far ahead of 0, the next BatchPosted event fails `MAX_BLOCK_GAP` and derivation wedges permanently.

### Incident timeline (testnet-eez 2026-04-16)

| Time (UTC) | Event |
|---|---|
| 05:19:56 | `entry not consumed after max deferrals — rewinding to rebuild with §4f-filtered txs` at L2 3354 (header_root `0x8ba138bc…` vs l1_state_root `0xb06f1ec5…`) |
| 05:19:57 | `FCU rewind did not unwind committed blocks — accepting reth canonical tip requested=3353 actual_tip=3354` → `immutable_block_ceiling = 3354` |
| 05:20 – 05:52 | 32 min of rewind cycles; rewind_target drifts 3354 → 3483 |
| 05:52:52 | `rolled back derivation state fork_point=3370 last_valid_l2=None` (cursor evicted) |
| 05:52:53 | `BatchPosted block 3354 exceeds MAX_BLOCK_GAP (1000): expected next block 1` — permanent wedge |

L1 on-chain state root `0xb06f1ec595778fe71769a5da92e76b287038a212abc0b5fe90a979dd14f142ea` verified byte-level against `Rollups.sol` event `0x46c9dcfa…` at L1 block 3371 (`lastStateUpdateBlock() = 3371`).

## Scope

Only the *secondary* wedge is fixed here — the one that turns a livelock into a permanent dead end.

The *primary* trigger (reth's FCU rewind refusing to unwind committed blocks, leaving speculative state at the L1-confirmed anchor) is **not** addressed in this PR. It needs a separate design — either a stronger unwind path or a guarantee that the builder doesn't commit speculative state at blocks pending L1 confirmation.

`DerivationPipeline::rollback_to`'s semantics are intentionally left untouched so all other callers (`driver/mod.rs` L1-reorg path, `driver/verify.rs` context / state-root mismatch paths) behave exactly as before. A defense-in-depth guard inside `rollback_to` was considered and rejected — it changed the API contract enough to break 4 existing e2e_anvil tests that depend on the `unwrap_or(0)` "reset to genesis" behavior as a primitive.

## Test plan

- [x] `cargo build -p based-rollup --release`
- [x] `cargo nextest run -p based-rollup --release derivation driver rewind rollback` — **215/215 passed**, including the 4 previously-relevant e2e_anvil rollback tests
- [x] `cargo clippy -p based-rollup --release --all-features` — 0 warnings, 0 errors
- [x] New regression: `test_rewind_sequence_leaves_derivation_head_at_target_when_cursor_empty` (exact testnet-eez sequence)
- [ ] Redeploy testnet-eez from this branch, confirm no recurrence

## References

- Incident evidence preserved at `/tmp/testnet-evidence/builder.full.log` on the investigating host (379 369 lines).
- `docs/issue-29-multiblock-filtering-bug.md` — related §4f filtering fix that is *necessary but insufficient*; this PR closes the secondary wedge that persists regardless of §4f correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)