### PR TITLE
fix(driver): complete post-commit divergence recovery via sibling-reorg path (follow-up to PR #39)

### DIFF
--- a/contracts/test-multi-call/src/CrossChainArb.sol
+++ b/contracts/test-multi-call/src/CrossChainArb.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC20 {
+    function balanceOf(address) external view returns (uint256);
+    function approve(address, uint256) external returns (bool);
+    function transfer(address, uint256) external returns (bool);
+}
+
+interface IAMM {
+    function swap(address tokenIn, uint256 amountIn) external returns (uint256);
+}
+
+interface IBridge {
+    function bridgeTokens(address token, uint256 amount, uint256 rollupId, address dest) external;
+}
+
+interface IL2Executor {
+    function swapAndBridgeBack(address tokenIn, address recipient) external returns (uint256);
+}
+
+/// @title CrossChainArb
+/// @notice Atomic cross-chain arbitrage between L1 and L2 AMM pools.
+///         Holds its own working capital (WETH). Bot off-chain decides direction
+///         and size. Each arb is atomic — reverts if profit < minProfit.
+///
+///         Two directions:
+///         - arbSellOnL2: bridge WETH to L2, sell WETH→USDC on L2, bridge USDC back,
+///                        buy WETH→USDC on L1. Profitable when L2 WETH price > L1 WETH price.
+///         - arbSellOnL1: swap WETH→USDC on L1, bridge USDC to L2, L2 swaps USDC→WETH,
+///                        bridge WETH back. Profitable when L1 WETH price > L2 WETH price.
+contract CrossChainArb {
+    address public weth;
+    address public usdc;
+    address public l1Amm;
+    address public bridge;
+    uint256 public rollupId;
+    address public l2Executor;
+    address public l2ExecutorProxy;
+    address public owner;
+
+    event ArbExecuted(uint8 direction, uint256 amountIn, uint256 profit);
+
+    constructor(
+        address _weth,
+        address _usdc,
+        address _l1Amm,
+        address _bridge,
+        uint256 _rollupId
+    ) {
+        weth = _weth;
+        usdc = _usdc;
+        l1Amm = _l1Amm;
+        bridge = _bridge;
+        rollupId = _rollupId;
+        owner = msg.sender;
+    }
+
+    function setL2Executor(address _executor, address _proxy) external {
+        require(msg.sender == owner, "only owner");
+        l2Executor = _executor;
+        l2ExecutorProxy = _proxy;
+    }
+
+    /// @notice Sell WETH on L2 (expensive), buy WETH on L1 (cheap).
+    ///         Profitable when L2 price > L1 price.
+    function arbSellOnL2(uint256 amountIn, uint256 minProfit) external returns (uint256 profit) {
+        require(msg.sender == owner, "only owner");
+        uint256 balBefore = IERC20(weth).balanceOf(address(this));
+        require(balBefore >= amountIn, "insufficient WETH");
+
+        // 1. Bridge WETH to L2 Executor
+        IERC20(weth).approve(bridge, amountIn);
+        IBridge(bridge).bridgeTokens(weth, amountIn, rollupId, l2Executor);
+
+        // 2. Call L2 Executor via proxy: swaps WETH→USDC on L2, bridges USDC back here
+        uint256 usdcBefore = IERC20(usdc).balanceOf(address(this));
+        (bool ok,) = l2ExecutorProxy.call(
+            abi.encodeCall(IL2Executor.swapAndBridgeBack, (weth, address(this)))
+        );
+        require(ok, "L2 executor call failed");
+        uint256 usdcReceived = IERC20(usdc).balanceOf(address(this)) - usdcBefore;
+        require(usdcReceived > 0, "no USDC received");
+
+        // 3. Swap USDC → WETH on L1 AMM
+        IERC20(usdc).approve(l1Amm, usdcReceived);
+        IAMM(l1Amm).swap(usdc, usdcReceived);
+
+        // 4. Profit check
+        uint256 balAfter = IERC20(weth).balanceOf(address(this));
+        require(balAfter >= balBefore + minProfit, "unprofitable");
+        profit = balAfter - balBefore;
+        emit ArbExecuted(0, amountIn, profit);
+    }
+
+    /// @notice Sell WETH on L1 (expensive), buy WETH on L2 (cheap).
+    ///         Profitable when L1 price > L2 price.
+    function arbSellOnL1(uint256 amountIn, uint256 minProfit) external returns (uint256 profit) {
+        require(msg.sender == owner, "only owner");
+        uint256 balBefore = IERC20(weth).balanceOf(address(this));
+        require(balBefore >= amountIn, "insufficient WETH");
+
+        // 1. Swap WETH → USDC on L1 AMM
+        IERC20(weth).approve(l1Amm, amountIn);
+        uint256 usdcOut = IAMM(l1Amm).swap(weth, amountIn);
+
+        // 2. Bridge USDC to L2 Executor
+        IERC20(usdc).approve(bridge, usdcOut);
+        IBridge(bridge).bridgeTokens(usdc, usdcOut, rollupId, l2Executor);
+
+        // 3. Call L2 Executor via proxy: swaps USDC→WETH on L2, bridges WETH back here
+        (bool ok,) = l2ExecutorProxy.call(
+            abi.encodeCall(IL2Executor.swapAndBridgeBack, (usdc, address(this)))
+        );
+        require(ok, "L2 executor call failed");
+
+        // 4. Profit check
+        uint256 balAfter = IERC20(weth).balanceOf(address(this));
+        require(balAfter >= balBefore + minProfit, "unprofitable");
+        profit = balAfter - balBefore;
+        emit ArbExecuted(1, amountIn, profit);
+    }
+
+    /// @notice Owner withdraw — for recovering funds.
+    function withdraw(address token, uint256 amount) external {
+        require(msg.sender == owner, "only owner");
+        IERC20(token).transfer(owner, amount);
+    }
+}

--- a/crates/based-rollup/src/driver/step_builder.rs
+++ b/crates/based-rollup/src/driver/step_builder.rs
@@ -573,6 +573,36 @@ where
                     break;
                 }
 
+                // If a sibling reorg has been queued (by Fix 1 / Fix 2 / verify
+                // fast-path), break out so `flush_to_l1`'s `flush_precheck` can
+                // dispatch it on the same tick. Without this, `verify_local_block_matches_l1`
+                // would fire `NoOpPendingSiblingReorg` → `Err`, which would
+                // propagate through `?` and short-circuit `step_builder` BEFORE
+                // `flush_to_l1` runs — the dispatch would never fire and the
+                // chain would wedge (byte-level evidence: 2026-04-18 devnet soak
+                // showed L2 stuck at block 71 for 23+ min with 38 NoOp Err
+                // events accumulating, never a dispatch).
+                //
+                // Skipping the verify loop here is safe because `step_sync`
+                // (which runs after the queued reorg transitions mode=Sync)
+                // re-processes these blocks via derivation and either calls
+                // `rebuild_block_as_sibling` for the target block (mod.rs:1133)
+                // or skips already-built blocks cleanly. Any non-target block
+                // that would have been verified here will be re-derived and
+                // verified by `step_sync` or re-fired by the builder loop once
+                // the reorg completes.
+                if self.pending_sibling_reorg.is_some() {
+                    info!(
+                        target: "based_rollup::driver",
+                        pending_target = self.pending_sibling_reorg.map(|r| r.target_l2_block),
+                        current_block_in_batch = block.l2_block_number,
+                        l2_head = self.l2_head_number,
+                        "derive_and_verify: breaking loop — pending sibling reorg queued, \
+                         letting flush_precheck dispatch it before any more verify calls"
+                    );
+                    break;
+                }
+
                 if block.l2_block_number <= self.l2_head_number {
                     // We already built this block locally. Verify it matches L1.
                     self.verify_local_block_matches_l1(block)?;
@@ -600,7 +630,12 @@ where
             // If a rewind was triggered during verification, do NOT commit the
             // batch — the cursor must stay so blocks are re-derived after the
             // rewind completes.
-            if self.pending_rewind_target.is_some() {
+            //
+            // Same rule applies when a sibling reorg is pending: we broke out
+            // of the loop early, so not all blocks were processed. Committing
+            // the cursor here would advance past blocks that must still be
+            // re-derived by `step_sync` to trigger the sibling-reorg rebuild.
+            if self.pending_rewind_target.is_some() || self.pending_sibling_reorg.is_some() {
                 return Ok(());
             }
 

--- a/crates/based-rollup/src/driver/types.rs
+++ b/crates/based-rollup/src/driver/types.rs
@@ -100,6 +100,23 @@ pub(super) enum VerificationDecision {
         target_l2_block: u64,
         expected_root: B256,
     },
+    /// §4f-flagged mismatch at a block while `pending_sibling_reorg` was
+    /// already queued (by Fix 1 / Fix 2 / verify fast-path on a prior tick).
+    /// The current divergence is expected to be resolved by the queued reorg
+    /// on a subsequent tick (via `flush_precheck` dispatch or `step_sync`'s
+    /// `rebuild_block_as_sibling`). The verify path intentionally does NOT
+    /// clear internal state (which would wipe the queued request) and does
+    /// NOT set `pending_rewind_target` (which would trigger bare FCU rewind).
+    /// The caller returns `Err` so the main loop's backoff machinery engages
+    /// while the queued reorg completes.
+    ///
+    /// Mirror telemetry only — the handler returns `Err` directly; this
+    /// variant exists so tests and the decision-log `trace!` can name the
+    /// branch taken.
+    SiblingReorgAlreadyQueued {
+        target_l2_block: u64,
+        queued_target: Option<u64>,
+    },
 }
 
 /// Outcome of verifying L2→L1 trigger receipts after a postBatch lands on L1.
@@ -611,6 +628,15 @@ pub(crate) enum VerifyMismatchAction {
     /// `plan_sibling_reorg_from_verify` + `apply_sibling_reorg_plan`. No
     /// deferral. This is the fast path (issue #36).
     FastPathSiblingReorg,
+    /// A sibling-reorg request is already queued (by Fix 1 / Fix 2 / verify
+    /// fast-path on a prior tick). The current mismatch is expected to be
+    /// resolved by that queued reorg — do NOT call `clear_internal_state`
+    /// (which would wipe the queued request), do NOT set
+    /// `pending_rewind_target` (which would trigger bare FCU rewind on the
+    /// next tick). Return Err so the main loop's backoff machinery engages,
+    /// and let the queued reorg complete on a subsequent tick via
+    /// `flush_precheck` dispatch or `step_sync`'s `rebuild_block_as_sibling`.
+    NoOpPendingSiblingReorg,
     /// Entry-bearing block with a pending hold — defer verification one more
     /// time so L1 has a chance to mine the consumption event.
     DeferEntryVerify,
@@ -645,6 +671,21 @@ pub(crate) fn classify_verify_mismatch(
     // Fast path: the two-pass C1 gate. Both conditions must be true.
     if filtering_present && !sibling_reorg_already_queued {
         return VerifyMismatchAction::FastPathSiblingReorg;
+    }
+    // §4f-shaped divergence at a block whose queued sibling reorg is about to
+    // fix it (production-critical bug from PR #39 soak — 55% of Fix 1
+    // recoveries silently fell through to bare FCU rewind because the verify
+    // path wiped `pending_sibling_reorg` via `clear_internal_state` and armed
+    // `pending_rewind_target` for a bare rewind on the next tick). Returning
+    // this variant tells the handler to do NOTHING to driver state and just
+    // return `Err` so backoff engages while the queued reorg completes.
+    //
+    // Must come BEFORE the entry-block check: a sibling reorg can legitimately
+    // be queued for an entry-bearing block (deposits/withdrawals divergence),
+    // and in that case we still want the queued reorg to win over the
+    // deferral/rewind paths.
+    if filtering_present && sibling_reorg_already_queued {
+        return VerifyMismatchAction::NoOpPendingSiblingReorg;
     }
     // Entry-bearing block with pending verification: defer or rewind depending
     // on how many deferrals we've already spent. The `+ 1` simulates the

--- a/crates/based-rollup/src/driver/verify.rs
+++ b/crates/based-rollup/src/driver/verify.rs
@@ -225,6 +225,47 @@ where
                         expected_root: derived.state_root,
                     });
                 }
+                VerifyMismatchAction::NoOpPendingSiblingReorg => {
+                    // Production-critical: a sibling-reorg request is already
+                    // queued for an earlier tick (by Fix 1 in flush_to_l1,
+                    // Fix 2 in flush_precheck, or the verify fast-path above
+                    // on a prior tick). `step_builder` / `step_sync` dispatch
+                    // will complete the reorg on a subsequent tick. If we
+                    // instead took the generic-rewind path we would
+                    // `clear_internal_state()` — wiping `pending_sibling_reorg`
+                    // — and `set_rewind_target()` — arming a bare FCU rewind.
+                    // On reth `--dev` bare FCU-to-ancestor accidentally works
+                    // because the auto-seal engine tolerates backward FCU; on
+                    // production Ethereum-engine reth it's a silent no-op per
+                    // Engine API spec, leaving the builder permanently
+                    // divergent from fullnodes.
+                    //
+                    // Return `Err` so the main loop's backoff machinery
+                    // engages, but do NOT mutate driver state: the queued
+                    // reorg stays intact and completes on its own.
+                    let queued_target = self.pending_sibling_reorg.map(|r| r.target_l2_block);
+                    let queued_expected_root = self.pending_sibling_reorg.map(|r| r.expected_root);
+                    warn!(
+                        target: "based_rollup::driver",
+                        l2_block = derived.l2_block_number,
+                        %header_root,
+                        l1_state_root = %derived.state_root,
+                        ?queued_target,
+                        ?queued_expected_root,
+                        "§4f divergence at verify but sibling reorg already queued — \
+                         returning Err to engage backoff; queued reorg will complete on a \
+                         subsequent tick (do NOT wipe pending_sibling_reorg or set \
+                         pending_rewind_target)"
+                    );
+                    let _decision = VerificationDecision::SiblingReorgAlreadyQueued {
+                        target_l2_block: derived.l2_block_number,
+                        queued_target,
+                    };
+                    return Err(eyre::eyre!(
+                        "state root mismatch at L2 block {} deferred to queued sibling reorg",
+                        derived.l2_block_number
+                    ));
+                }
                 VerifyMismatchAction::DeferEntryVerify => {
                     // Existing hold-defer branch — the classifier identified
                     // `is_pending_entry_block && deferrals < MAX-1`.

--- a/crates/based-rollup/src/driver_tests.rs
+++ b/crates/based-rollup/src/driver_tests.rs
@@ -5741,3 +5741,576 @@ mod post_commit_anchor_divergence {
     //     flush pipeline mockable. Out of scope for this PR.
     // ─────────────────────────────────────────────────────────────────────
 }
+
+// =============================================================================
+// NoOpPendingSiblingReorg integration tests (PR #39 soak fix / Option B).
+//
+// Production-critical bug: before Option B, `verify_local_block_matches_l1`
+// handled `(filtering_present=true, already_queued=true)` by falling through
+// to `GenericMismatchRewind`. That arm calls `clear_internal_state()`
+// (wiping the queued `pending_sibling_reorg`) AND
+// `set_rewind_target(entry_block - 1)` (arming bare FCU rewind on the next
+// tick). On reth `--dev` the bare FCU "rewinds" by a happy accident of the
+// auto-seal engine; on production Ethereum-engine reth it is a silent no-op
+// per Engine API spec, leaving the builder permanently divergent from
+// fullnodes — the state the byte-level forensic evidence showed in the
+// 60-min devnet soak (42 of 76 Fix 1 queues wiped by bare FCU rewinds).
+//
+// The fix introduces `VerifyMismatchAction::NoOpPendingSiblingReorg` in the
+// classifier and a paired handler arm in `verify.rs` that returns `Err`
+// WITHOUT touching driver state. The pure-logic coverage (classifier truth
+// table) lives in `test_verify_non_filtering_mismatch_uses_deferral_path`.
+// The tests below complement that pure-logic coverage with:
+//
+//   Group A — state preservation invariants: the handler semantics preserve
+//             `pending_sibling_reorg` and leave `pending_rewind_target` unset.
+//   Group B — staleness convergence: once the queued reorg completes, a
+//             subsequent mismatch at a later block requalifies for the
+//             FastPathSiblingReorg branch.
+//   Group C — priority over entry-block branches: harness-level wire-through
+//             confirming the classifier wins over `DeferEntryVerify` /
+//             `ExhaustedDeferralRewind` even when both triggers fire.
+//
+// Group D (full async verify_local_block_matches_l1 end-to-end) is SKIPPED
+// with a NOTE: see the skip-rationale comment below. The existing harness
+// can satisfy `self.l2_provider.sealed_header(N)` only by returning `None`
+// for any `N != genesis`, which short-circuits at the `Skip` branch before
+// reaching the classifier. Reaching the mismatch branch for real requires
+// (a) a mock provider that can return a `SealedHeader` with a specified
+// `mix_hash` + `state_root`, or (b) an `EngineClient`-style trait extraction
+// for the `sealed_header` read similar to REQUEST C above.
+// =============================================================================
+
+#[cfg(any(test, feature = "test-utils"))]
+mod noop_pending_sibling_reorg_integration {
+    use super::*;
+    use crate::driver::{
+        EntryVerificationHold, MAX_ENTRY_VERIFY_DEFERRALS, SiblingReorgRequest,
+        VerifyMismatchAction, classify_verify_mismatch, plan_sibling_reorg_from_verify,
+    };
+    use crate::driver_test_harness::DriverTestHarness;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Group A — state preservation invariants.
+    //
+    // The handler arm in verify.rs at lines ~228–268 for
+    // `NoOpPendingSiblingReorg` is intentionally a no-op on driver state:
+    // only a `warn!` log and a `return Err(...)`. These tests verify that
+    // whenever the classifier picks this branch, the harness-observable
+    // state is unchanged by "applying" the handler semantics (which is
+    // nothing but the classifier call itself — no state mutation).
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// The queued `SiblingReorgRequest` MUST survive the verify path when the
+    /// classifier returns `NoOpPendingSiblingReorg`. This is the exact
+    /// invariant that Option B restores — the old path called
+    /// `clear_internal_state()` which wiped `pending_sibling_reorg` via the
+    /// `clear_recovery_state` helper.
+    #[test]
+    fn test_verify_noop_when_sibling_queued_preserves_pending_request() {
+        let mut harness = DriverTestHarness::new();
+
+        // Seed: a sibling-reorg request already queued by a prior tick
+        // (by Fix 1 in flush_to_l1, Fix 2 in flush_precheck, or the verify
+        // fast-path on a previous iteration).
+        let queued = SiblingReorgRequest {
+            target_l2_block: 42,
+            expected_root: B256::with_last_byte(0x77),
+        };
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(queued));
+
+        // Snapshot of rewind target BEFORE — must be None and stay None.
+        assert_eq!(harness.driver.pending_rewind_target_for_test(), None);
+
+        // Classifier gate for the verify path: when verify_local_block_matches_l1
+        // enters the `header_root != derived.state_root` mismatch branch, it
+        // calls `classify_verify_mismatch` with these exact arguments. For the
+        // "queued reorg wins" branch we want:
+        //   filtering_present=true (derived.filtering.is_some())
+        //   sibling_reorg_already_queued=true (self.pending_sibling_reorg.is_some())
+        //   is_pending_entry_block=false (not blocking on an entry hold)
+        //   deferrals_before_increment=0
+        //   max_deferrals=MAX_ENTRY_VERIFY_DEFERRALS
+        let action = classify_verify_mismatch(
+            /* filtering_present = */ true,
+            /* sibling_reorg_already_queued = */
+            harness.driver.pending_sibling_reorg_for_test().is_some(),
+            /* is_pending_entry_block = */ false,
+            /* deferrals_before_increment = */ 0,
+            MAX_ENTRY_VERIFY_DEFERRALS,
+        );
+        assert_eq!(action, VerifyMismatchAction::NoOpPendingSiblingReorg);
+
+        // The handler arm for `NoOpPendingSiblingReorg` in verify.rs returns
+        // Err without mutating state (by construction; see verify.rs:228-268).
+        // Confirm the end-state is identical to the seeded state.
+        assert_eq!(
+            harness.driver.pending_sibling_reorg_for_test(),
+            Some(queued),
+            "queued sibling-reorg request MUST survive verify path when classifier \
+             returns NoOpPendingSiblingReorg (regression: old path called \
+             clear_internal_state → pending_sibling_reorg=None)"
+        );
+        // Original target + root both preserved.
+        let after = harness
+            .driver
+            .pending_sibling_reorg_for_test()
+            .expect("Some above");
+        assert_eq!(after.target_l2_block, 42, "target unchanged");
+        assert_eq!(
+            after.expected_root,
+            B256::with_last_byte(0x77),
+            "expected_root unchanged"
+        );
+    }
+
+    /// The handler MUST NOT set `pending_rewind_target`. The old
+    /// `GenericMismatchRewind` arm called `set_rewind_target(entry_block-1)`
+    /// which armed a bare FCU rewind on the next tick — the second half of
+    /// the production bug.
+    #[test]
+    fn test_verify_noop_does_not_set_pending_rewind_target() {
+        let mut harness = DriverTestHarness::new();
+
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(SiblingReorgRequest {
+                target_l2_block: 100,
+                expected_root: B256::with_last_byte(0x11),
+            }));
+        // Confirm starting state.
+        assert_eq!(harness.driver.pending_rewind_target_for_test(), None);
+
+        let action = classify_verify_mismatch(true, true, false, 0, MAX_ENTRY_VERIFY_DEFERRALS);
+        assert_eq!(action, VerifyMismatchAction::NoOpPendingSiblingReorg);
+
+        // Handler does nothing to state — pending_rewind_target stays None.
+        assert_eq!(
+            harness.driver.pending_rewind_target_for_test(),
+            None,
+            "NoOpPendingSiblingReorg handler MUST NOT arm pending_rewind_target — \
+             doing so would trigger bare FCU rewind on the next tick (silent no-op \
+             on production Ethereum-engine reth, per Engine API spec)"
+        );
+    }
+
+    /// Edge case from the task spec: when `pending_sibling_reorg` is queued
+    /// for block K and verify fires on block K ITSELF (not K+M). The
+    /// classifier must still return `NoOpPendingSiblingReorg` — letting the
+    /// queued reorg target K handle its own divergence rather than forcing a
+    /// double-dispatch.
+    #[test]
+    fn test_verify_noop_when_queued_reorg_targets_same_block_as_verify() {
+        let mut harness = DriverTestHarness::new();
+
+        let same_block = 555u64;
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(SiblingReorgRequest {
+                target_l2_block: same_block,
+                expected_root: B256::with_last_byte(0x33),
+            }));
+
+        // Verify fires for the same block K. Classifier inputs:
+        //   filtering_present=true (the whole point: §4f flagged this block)
+        //   sibling_reorg_already_queued=true (queued for K)
+        //   is_pending_entry_block=false (but see the paired test below
+        //                                 where this is true)
+        let action = classify_verify_mismatch(true, true, false, 0, MAX_ENTRY_VERIFY_DEFERRALS);
+        assert_eq!(
+            action,
+            VerifyMismatchAction::NoOpPendingSiblingReorg,
+            "queued reorg for K + verify mismatch at K → handler lets queued reorg \
+             run to completion; a second dispatch would be redundant and risks \
+             racing with the in-flight rebuild_block_as_sibling call"
+        );
+
+        // State unchanged.
+        let still = harness
+            .driver
+            .pending_sibling_reorg_for_test()
+            .expect("still queued");
+        assert_eq!(still.target_l2_block, same_block);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Group B — staleness convergence.
+    //
+    // After the queued reorg completes and clears itself (via
+    // `rebuild_block_as_sibling` success + `clear_fields_on_sibling_reorg_success`),
+    // a subsequent verify mismatch at a later block must re-qualify for
+    // `FastPathSiblingReorg` (`sibling_reorg_already_queued=false`), NOT
+    // stay parked in the no-op branch forever.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Staleness convergence: queued reorg for block 100 must NOT block a
+    /// fresh §4f divergence at block 103 from queueing. The sequence:
+    ///   1. Verify at 103 with queued=100 → NoOpPendingSiblingReorg.
+    ///   2. Queued reorg for 100 completes (cleared).
+    ///   3. Verify at 103 again → FastPathSiblingReorg (fresh queue).
+    #[test]
+    fn test_queued_reorg_for_block_n_survives_verify_on_block_n_plus_m() {
+        let mut harness = DriverTestHarness::new();
+
+        // Phase 1: seed queued reorg for block 100. Verify fires at 103
+        // (later block, §4f divergence).
+        let queued_for_100 = SiblingReorgRequest {
+            target_l2_block: 100,
+            expected_root: B256::with_last_byte(0x66),
+        };
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(queued_for_100));
+
+        let action = classify_verify_mismatch(
+            /* filtering_present = */ true,
+            /* queued = */ harness.driver.pending_sibling_reorg_for_test().is_some(),
+            /* entry_block = */ false,
+            /* deferrals = */ 0,
+            MAX_ENTRY_VERIFY_DEFERRALS,
+        );
+        assert_eq!(
+            action,
+            VerifyMismatchAction::NoOpPendingSiblingReorg,
+            "verify at 103 must defer to the queued-for-100 reorg"
+        );
+        // State unchanged — queued request for 100 still there.
+        assert_eq!(
+            harness.driver.pending_sibling_reorg_for_test(),
+            Some(queued_for_100)
+        );
+
+        // Phase 2: the queued reorg for block 100 completes. In production
+        // `clear_fields_on_sibling_reorg_success` wipes pending_sibling_reorg
+        // on the successful rebuild path.
+        harness.driver.set_pending_sibling_reorg_for_test(None);
+        assert_eq!(harness.driver.pending_sibling_reorg_for_test(), None);
+
+        // Phase 3: verify fires again at 103. With queued=None, the fast path
+        // must fire — otherwise a real §4f divergence at 103 would loop
+        // forever in the no-op branch.
+        let action_after_clear = classify_verify_mismatch(
+            /* filtering_present = */ true,
+            /* queued = */ harness.driver.pending_sibling_reorg_for_test().is_some(),
+            /* entry_block = */ false,
+            /* deferrals = */ 0,
+            MAX_ENTRY_VERIFY_DEFERRALS,
+        );
+        assert_eq!(
+            action_after_clear,
+            VerifyMismatchAction::FastPathSiblingReorg,
+            "after queued reorg clears, a fresh §4f divergence MUST re-qualify \
+             for the fast path (else the system deadlocks on permanent no-op)"
+        );
+
+        // In production, the FastPath handler calls
+        // `plan_sibling_reorg_from_verify` + `apply_sibling_reorg_plan`, which
+        // install a fresh request. Simulate the install step so the test
+        // captures the full convergence behavior end-to-end.
+        let plan = plan_sibling_reorg_from_verify(
+            /* entry_block = */ 103,
+            /* expected_root = */ B256::with_last_byte(0x99),
+            /* anchor = */ None,
+            /* deployment_l1_block = */ 100,
+        );
+        harness.driver.apply_sibling_reorg_plan_for_test(plan);
+        let fresh = harness
+            .driver
+            .pending_sibling_reorg_for_test()
+            .expect("fresh queue");
+        assert_eq!(
+            fresh.target_l2_block, 103,
+            "fresh request must target the block that actually diverged"
+        );
+    }
+
+    /// When the queued reorg clears but the NEXT divergence is also §4f-shaped
+    /// and happens at the SAME block that was just rebuilt, the fast path
+    /// must still queue a fresh request. (The sibling-reorg plan may itself
+    /// need re-running — e.g., a second §4f filter refinement.)
+    #[test]
+    fn test_queued_reorg_for_block_n_cleared_then_second_divergence_at_same_n() {
+        let mut harness = DriverTestHarness::new();
+
+        // Phase 1: first divergence at 200, queued + then cleared (reorg ran).
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(SiblingReorgRequest {
+                target_l2_block: 200,
+                expected_root: B256::with_last_byte(0x10),
+            }));
+        harness.driver.set_pending_sibling_reorg_for_test(None);
+
+        // Phase 2: verify at 200 again sees a second §4f divergence — fresh
+        // queue required.
+        let action = classify_verify_mismatch(
+            true,
+            harness.driver.pending_sibling_reorg_for_test().is_some(),
+            false,
+            0,
+            MAX_ENTRY_VERIFY_DEFERRALS,
+        );
+        assert_eq!(
+            action,
+            VerifyMismatchAction::FastPathSiblingReorg,
+            "second §4f divergence at the SAME block after the first clears must \
+             re-qualify for the fast path — no permanent no-op"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Group C — priority over entry-block branches (harness wire-through).
+    //
+    // The classifier order is `NoOpPendingSiblingReorg` BEFORE the
+    // `is_pending_entry_block` branches. This is the critical ordering that
+    // the pure-logic tests at driver_tests.rs:4772-4782 already cover. The
+    // harness-level versions below add the state-preservation assertion
+    // that the entry-block branches WOULD otherwise trip: if classifier
+    // ordering ever regresses so DeferEntryVerify / ExhaustedDeferralRewind
+    // fires, the harness state would change — `hold.defer()` would bump the
+    // deferral counter, `rewind_to_re_derive` would set
+    // `pending_rewind_target`. The invariants here capture that NONE of
+    // those side effects happen when the queued reorg should win.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Harness version of the classifier precedence test at
+    /// driver_tests.rs:4772-4776. When filtering + queued + entry-block all
+    /// true with fresh deferrals, classifier returns NoOpPendingSiblingReorg
+    /// — and the harness confirms the hold state is unchanged (otherwise
+    /// `DeferEntryVerify` would have bumped `hold.deferrals()` via
+    /// `self.hold.defer()` in verify.rs).
+    #[test]
+    fn test_noop_sibling_reorg_takes_precedence_over_defer_entry_verify() {
+        let mut harness = DriverTestHarness::new();
+
+        // Seed: queued reorg + armed hold on same block + fresh deferrals.
+        let entry_block = 5354u64;
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(SiblingReorgRequest {
+                target_l2_block: entry_block,
+                expected_root: B256::with_last_byte(0x44),
+            }));
+        harness.driver.arm_hold_for_test(entry_block);
+        // Hold armed, deferrals still 0.
+        assert!(harness.driver.hold_for_test().is_armed_for(entry_block));
+        assert_eq!(harness.driver.hold_for_test().deferrals(), 0);
+
+        let action = classify_verify_mismatch(
+            /* filtering_present = */ true,
+            /* queued = */ true,
+            /* entry_block = */ true,
+            /* deferrals_before_increment = */ 0,
+            /* max = */ MAX_ENTRY_VERIFY_DEFERRALS,
+        );
+        assert_eq!(
+            action,
+            VerifyMismatchAction::NoOpPendingSiblingReorg,
+            "queued reorg must WIN over DeferEntryVerify — otherwise verify would \
+             call hold.defer() and burn a deferral on a block already scheduled \
+             for sibling reorg"
+        );
+
+        // Handler state-preservation invariants — none of these would hold
+        // if the `DeferEntryVerify` arm had fired:
+        //   (a) pending_sibling_reorg unchanged
+        assert!(harness.driver.pending_sibling_reorg_for_test().is_some());
+        //   (b) hold.deferrals() still 0 — `DeferEntryVerify` would bump this
+        //       to 1 via `hold.defer()`.
+        assert_eq!(
+            harness.driver.hold_for_test().deferrals(),
+            0,
+            "DeferEntryVerify would have bumped deferrals to 1; NoOp must not"
+        );
+        //   (c) pending_rewind_target still None.
+        assert_eq!(harness.driver.pending_rewind_target_for_test(), None);
+    }
+
+    /// Harness version of driver_tests.rs:4777-4782. When deferrals are
+    /// exhausted, classifier STILL returns NoOpPendingSiblingReorg (not
+    /// ExhaustedDeferralRewind). The harness confirms that
+    /// `rewind_to_re_derive` was not called: the derivation cursor, rewind
+    /// target, consecutive_rewind_cycles, and hold state are all pristine.
+    #[test]
+    fn test_noop_sibling_reorg_takes_precedence_over_exhausted_deferral_rewind() {
+        let mut harness = DriverTestHarness::new();
+
+        let entry_block = 5354u64;
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(SiblingReorgRequest {
+                target_l2_block: entry_block,
+                expected_root: B256::with_last_byte(0x55),
+            }));
+        harness.driver.arm_hold_for_test(entry_block);
+        // Pre-burn 2 deferrals so the next defer would trip the exhaustion
+        // branch (MAX_ENTRY_VERIFY_DEFERRALS = 3, so deferrals_before+1=3).
+        // We do this by applying the hold's own defer() twice. Verify the
+        // pre-state matches the classifier's input expectation.
+        {
+            let mut hold = harness.driver.hold_for_test();
+            hold.defer();
+            hold.defer();
+            assert_eq!(hold.deferrals(), 2);
+        }
+        // The classifier takes deferrals as input — we pass 2 directly so
+        // the test does not depend on mutating `self.hold` through a
+        // restricted API.
+        let action = classify_verify_mismatch(
+            /* filtering_present = */ true,
+            /* queued = */ true,
+            /* entry_block = */ true,
+            /* deferrals_before_increment = */ 2,
+            /* max = */ MAX_ENTRY_VERIFY_DEFERRALS,
+        );
+        assert_eq!(
+            action,
+            VerifyMismatchAction::NoOpPendingSiblingReorg,
+            "queued reorg must WIN over ExhaustedDeferralRewind — otherwise verify \
+             would call rewind_to_re_derive, wiping the queued request AND setting \
+             pending_rewind_target (bare FCU rewind on next tick)"
+        );
+
+        // ExhaustedDeferralRewind would have:
+        //   (a) cleared pending_sibling_reorg via clear_internal_state
+        //   (b) set pending_rewind_target = entry_block - 1
+        //   (c) incremented consecutive_rewind_cycles
+        //   (d) called derivation.rollback_to(...)
+        //   (e) cleared the hold
+        // None of those should have fired.
+        assert!(
+            harness.driver.pending_sibling_reorg_for_test().is_some(),
+            "request MUST remain queued"
+        );
+        assert_eq!(
+            harness.driver.pending_rewind_target_for_test(),
+            None,
+            "bare rewind target MUST NOT be armed"
+        );
+        assert_eq!(harness.driver.consecutive_rewind_cycles_for_test(), 0);
+        // hold still armed (not touched by classifier).
+        assert!(harness.driver.hold_for_test().is_armed());
+    }
+
+    /// Combined wire-through: two consecutive ticks with queued reorg. The
+    /// state invariants compose — classifier output NoOpPendingSiblingReorg
+    /// on tick N AND tick N+1, and the queued request survives both.
+    ///
+    /// Guards against a regression where the handler arm is idempotent on a
+    /// single call but leaves state that breaks on a second call (e.g., a
+    /// deferral counter that gets bumped by a buggy fall-through).
+    #[test]
+    fn test_noop_pending_sibling_reorg_idempotent_across_ticks() {
+        let mut harness = DriverTestHarness::new();
+        let queued = SiblingReorgRequest {
+            target_l2_block: 77,
+            expected_root: B256::with_last_byte(0x2A),
+        };
+        harness
+            .driver
+            .set_pending_sibling_reorg_for_test(Some(queued));
+
+        // Capture initial state.
+        let before_pending_reorg = harness.driver.pending_sibling_reorg_for_test();
+        let before_rewind_target = harness.driver.pending_rewind_target_for_test();
+        let before_cycles = harness.driver.consecutive_rewind_cycles_for_test();
+
+        // Tick 1: classifier returns NoOp.
+        let action_1 = classify_verify_mismatch(true, true, false, 0, MAX_ENTRY_VERIFY_DEFERRALS);
+        assert_eq!(action_1, VerifyMismatchAction::NoOpPendingSiblingReorg);
+
+        // Tick 2: same inputs, same outcome. Request still queued.
+        let action_2 = classify_verify_mismatch(
+            true,
+            harness.driver.pending_sibling_reorg_for_test().is_some(),
+            false,
+            0,
+            MAX_ENTRY_VERIFY_DEFERRALS,
+        );
+        assert_eq!(action_2, VerifyMismatchAction::NoOpPendingSiblingReorg);
+
+        // All state identical — two ticks in a row preserved everything.
+        assert_eq!(
+            harness.driver.pending_sibling_reorg_for_test(),
+            before_pending_reorg
+        );
+        assert_eq!(
+            harness.driver.pending_rewind_target_for_test(),
+            before_rewind_target
+        );
+        assert_eq!(
+            harness.driver.consecutive_rewind_cycles_for_test(),
+            before_cycles
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Group D — end-to-end verify_local_block_matches_l1 (SKIPPED).
+    //
+    // SKIP RATIONALE: `verify_local_block_matches_l1` delegates to
+    // `classify_and_apply_verification`, which begins with
+    // `self.l2_provider.sealed_header(derived.l2_block_number)`. The existing
+    // `DriverTestHarness` wires a `BlockchainProvider::with_latest` over a
+    // fresh `create_test_provider_factory()` — sealed_header for any block
+    // number other than the dummy genesis returns `Ok(None)`, so the verify
+    // path returns `VerificationDecision::Skip` without ever reaching the
+    // mismatch branch or the classifier.
+    //
+    // Two options to unlock this:
+    //   (a) Extend the harness with `seed_local_header(l2_block_number,
+    //       mix_hash, state_root)` that inserts a `SealedHeader` into the
+    //       provider. This is test-utils-only plumbing, ~30 lines, and
+    //       would unlock the full end-to-end path for this test AND the
+    //       existing L1ContextMismatchRewound / MismatchPermanent paths.
+    //   (b) Extract a `StateProviderRead` trait around `sealed_header`
+    //       (REQUEST C in `post_commit_anchor_divergence`) and mock it.
+    //
+    // Until (a) or (b) lands, the classifier-level tests above + the
+    // handler-arm inspection in verify.rs:228-268 are the tightest
+    // coverage achievable. The production invariant is:
+    //   `NoOpPendingSiblingReorg` handler produces NO driver-state mutation,
+    //   only `return Err(...)`. That is verified by inspecting verify.rs
+    //   directly (code-review guarantee: the arm's body is 4 lines of
+    //   locals + a `warn!` + a `return Err(...)`) and by the classifier
+    //   wire-through tests above that prove the classifier picks this
+    //   variant whenever `(filtering_present=true, queued=true)` holds.
+    //
+    // ASK for core-worker: seed_local_header harness method, OR
+    // `StateProviderRead` trait on `Driver<P, Pool>`.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Placeholder for the skipped Group D test — kept so that when the
+    /// harness grows `seed_local_header`, this placeholder can be rewritten
+    /// into a real end-to-end test. `#[ignore]` ensures `cargo nextest run`
+    /// does not report a false negative.
+    ///
+    /// The body below is a SKELETON of what the real test should do.
+    #[test]
+    #[ignore = "requires DriverTestHarness::seed_local_header or StateProviderRead \
+                trait extraction — see SKIP RATIONALE above"]
+    fn test_harness_integration_fix1_queue_survives_verify_tick() {
+        // SKELETON — enable after harness plumbing lands:
+        //   1. Build a harness.
+        //   2. Seed a local header at block N with mix_hash=L1_CTX,
+        //      state_root=LOCAL_ROOT, and any well-known parent_beacon_block_root.
+        //   3. Queue `pending_sibling_reorg` for N.
+        //   4. Construct DerivedBlock { l2_block_number=N,
+        //                               l1_info.l1_block_number=L1_CTX,
+        //                               state_root=DERIVED_ROOT /* != LOCAL_ROOT */,
+        //                               filtering=Some(DeferredFiltering{...}) }.
+        //   5. Call `harness.driver.verify_local_block_matches_l1(&derived)`.
+        //   6. Assert the call returned Err (backoff engages).
+        //   7. Assert `harness.driver.pending_sibling_reorg_for_test() == Some(_)`.
+        //   8. Assert `harness.driver.pending_rewind_target_for_test() == None`.
+        //
+        // These are the exact assertions from the task spec's Group D.
+
+        // Minimal placeholder so the test is parseable. Replace wholesale
+        // when plumbing lands. We do not construct the harness here to
+        // avoid flagging the test as flaky on ignore-lift; the skeleton in
+        // comments is the load-bearing description.
+        let _ = EntryVerificationHold::Clear;
+    }
+}

--- a/crates/based-rollup/src/driver_tests.rs
+++ b/crates/based-rollup/src/driver_tests.rs
@@ -4743,8 +4743,12 @@ fn test_verify_non_filtering_mismatch_uses_deferral_path() {
     );
     assert_eq!(
         classify_verify_mismatch(true, true, false, 0, 3),
-        VerifyMismatchAction::GenericMismatchRewind,
-        "already queued → no double-queue"
+        VerifyMismatchAction::NoOpPendingSiblingReorg,
+        "already queued → no-op (preserve pending_sibling_reorg; avoid \
+         bare FCU rewind). PR #39 soak uncovered that this previously \
+         fell through to GenericMismatchRewind, which called \
+         clear_internal_state (wiping the queued request) and set \
+         pending_rewind_target (triggering bare FCU on the next tick)."
     );
     assert_eq!(
         classify_verify_mismatch(false, false, true, 0, 3),
@@ -4760,6 +4764,21 @@ fn test_verify_non_filtering_mismatch_uses_deferral_path() {
         classify_verify_mismatch(false, false, false, 0, 3),
         VerifyMismatchAction::GenericMismatchRewind,
         "non-filtering, no entry block → generic rewind"
+    );
+    // Option B (PR #39 soak fix): `NoOpPendingSiblingReorg` must take
+    // precedence over the entry-block branches when a sibling reorg is
+    // already queued. Otherwise a queued reorg for an entry-bearing block
+    // would be wiped by the deferral-exhausted rewind path.
+    assert_eq!(
+        classify_verify_mismatch(true, true, true, 0, 3),
+        VerifyMismatchAction::NoOpPendingSiblingReorg,
+        "filtering + already-queued + entry-block → queued reorg wins over defer"
+    );
+    assert_eq!(
+        classify_verify_mismatch(true, true, true, 2, 3),
+        VerifyMismatchAction::NoOpPendingSiblingReorg,
+        "filtering + already-queued + entry-block + exhausted → queued reorg wins \
+         over rewind (do NOT clear_internal_state + set pending_rewind_target)"
     );
 }
 

--- a/scripts/e2e/arb-soak/README.md
+++ b/scripts/e2e/arb-soak/README.md
@@ -1,0 +1,82 @@
+# arb-soak — cross-chain contention soak test
+
+Adapted from [PR #33](https://github.com/eez-association/sync-rollups-composer/pull/33)
+(koeppelmann's `arb-bot-reproducer`). Deterministically reproduces the
+L2-rewind-loop / monotonic-lag symptoms tracked in issue #35.
+
+## Stack
+
+- `contracts/test-multi-call/src/CrossChainArb.sol` — atomic cross-chain
+  arbitrage contract; holds WETH working capital, sends `arbSellOnL1` /
+  `arbSellOnL2` that each fan out into bridge + cross-chain call.
+- Two `CrossChainArb` instances race for the same opportunity — this is
+  the contention pattern that drove issue #35.
+- One random trader (`trader.py`) creates price moves on L1 and L2 AMMs
+  so arb opportunities exist.
+- `monitor.py` samples the health endpoint + parses bot logs and produces
+  a pass/fail verdict.
+
+## Pass criteria (all must hold for the run's duration)
+
+- `healthy == true` at ≥95% of samples
+- `consecutive_rewind_cycles` never exceeds `MAX_FLUSH_MISMATCHES = 2`
+- L2 ↔ L1-derivation-head lag stays ≤ 20 blocks
+- Builder/Sync mode does not oscillate more than 3 times in any 60s window
+- Cross-chain tx success rate ≥ 5% after a 60s warmup (once 10+ attempts
+  have happened)
+- No "anchor-block divergence … halting" ERROR lines in builder logs
+
+Any single violation → FAIL.
+
+## Running
+
+### Devnet (default ports 11555/11556/11545/11560)
+
+```bash
+HEALTH_URL=http://localhost:11560/health \
+L1_RPC=http://localhost:11555 \
+L1_PROXY=http://localhost:11556 \
+L2_RPC=http://localhost:11545 \
+SOAK_DURATION=1800 \
+./scripts/e2e/arb-soak/run.sh
+```
+
+### Testnet (default ports 9555/9556/9545/9560)
+
+```bash
+SOAK_DURATION=1800 ./scripts/e2e/arb-soak/run.sh
+```
+
+### Skipping setup on re-runs
+
+```bash
+SOAK_SKIP_SETUP=1 SOAK_DURATION=3600 ./scripts/e2e/arb-soak/run.sh
+```
+
+Reuses the previously deployed `CrossChainArb` + AMMs from
+`/tmp/arb_config{,_2}.json`.
+
+## Files produced
+
+| path | purpose |
+|---|---|
+| `/tmp/arb_config.json`, `/tmp/arb_config_2.json` | per-bot deploy config |
+| `/tmp/arb_bot.log`, `/tmp/arb_bot2.log` | per-bot attempt log |
+| `/tmp/arb_bot_heartbeat.log` (etc.) | latest-state heartbeat per bot |
+| `/tmp/trader.log` | trader activity |
+| `/tmp/soak-verdict.json` | final JSON verdict (pass/fail + metrics) |
+
+## Expected outcomes by image version
+
+| image commit | expected verdict at 30 min |
+|---|---|
+| pre-PR#38 (sibling-reorg) | FAIL — monotonic lag + rewind cycles |
+| PR#38 only | FAIL at the L1→L2 zero-consumption path (~90 min) |
+| PR#39 | PASS if Fix 1 + Fix 2 cover all observed divergences |
+| PR#39 + Gap-1/2/3 extension | target PASS for 3h+ |
+
+## Non-goals
+
+- This is **not** a pure-Bash test. The arb-simulation math and the random
+  trader are Python. Same split PR #33 uses — proven to reproduce.
+- No dashboard. Use `tail -f /tmp/arb_bot*.log` for live view.

--- a/scripts/e2e/arb-soak/bot.py
+++ b/scripts/e2e/arb-soak/bot.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Arb bot — time-bounded variant of PR #33's arb_bot.py.
+
+Polls L1 and L2 AMM reserves every POLL_INTERVAL seconds. When a profitable
+cross-chain arb exists, sends a tx via CrossChainArb on the L1 composer proxy.
+Exits 0 on clean completion after --duration seconds.
+
+Writes:
+- {log_file}: per-attempt lines (OPPORTUNITY / SUCCESS / REVERTED / SEND ERROR)
+- {heartbeat_file}: last-seen state (overwritten each iteration)
+- stdout: one JSON summary line per 10 iterations (for monitor.py to parse)
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from web3 import Web3
+from eth_account import Account
+
+
+def log(line, log_file):
+    ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    msg = f'{ts} {line}'
+    print(msg, flush=True)
+    with open(log_file, 'a') as f:
+        f.write(msg + '\n')
+
+
+def swap_out(amount_in, reserve_in, reserve_out, fee_num=997, fee_den=1000):
+    if amount_in == 0:
+        return 0
+    amount_in_with_fee = amount_in * fee_num
+    num = amount_in_with_fee * reserve_out
+    den = reserve_in * fee_den + amount_in_with_fee
+    return num // den
+
+
+def sim_arb_sell_on_l1(amount, l1w, l1u, l2w, l2u):
+    usdc_out = swap_out(amount, l1w, l1u)
+    if usdc_out == 0:
+        return 0
+    return swap_out(usdc_out, l2u, l2w)
+
+
+def sim_arb_sell_on_l2(amount, l1w, l1u, l2w, l2u):
+    usdc_out = swap_out(amount, l2w, l2u)
+    if usdc_out == 0:
+        return 0
+    return swap_out(usdc_out, l1u, l1w)
+
+
+def find_optimal_arb(l1w, l1u, l2w, l2u, max_amount):
+    best = (None, 0, 0)
+    sizes = set()
+    for exp in range(15, int.bit_length(max_amount)):
+        v = 1 << exp
+        if v <= max_amount:
+            sizes.add(v)
+    for frac in (0.01, 0.05, 0.1, 0.2, 0.3, 0.5, 0.7, 0.9, 1.0):
+        sizes.add(int(max_amount * frac))
+    sizes = sorted(s for s in sizes if 10**14 <= s <= max_amount)
+
+    for amt in sizes:
+        out1 = sim_arb_sell_on_l1(amt, l1w, l1u, l2w, l2u)
+        if out1 - amt > best[2]:
+            best = ('l1', amt, out1 - amt)
+        out2 = sim_arb_sell_on_l2(amt, l1w, l1u, l2w, l2u)
+        if out2 - amt > best[2]:
+            best = ('l2', amt, out2 - amt)
+
+    direction, size, profit = best
+    if direction is None:
+        return None, 0, 0
+
+    sim = sim_arb_sell_on_l1 if direction == 'l1' else sim_arb_sell_on_l2
+    lo = max(10**14, size // 4)
+    hi = min(max_amount, size * 4)
+    for _ in range(30):
+        m1 = lo + (hi - lo) // 3
+        m2 = hi - (hi - lo) // 3
+        p1 = sim(m1, l1w, l1u, l2w, l2u) - m1
+        p2 = sim(m2, l1w, l1u, l2w, l2u) - m2
+        if p1 < p2:
+            lo = m1
+        else:
+            hi = m2
+        if hi - lo < 10**12:
+            break
+    amt = (lo + hi) // 2
+    return direction, amt, sim(amt, l1w, l1u, l2w, l2u) - amt
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('config', help='path to arb_config.json')
+    ap.add_argument('--duration', type=int, default=600, help='seconds to run')
+    ap.add_argument('--poll', type=int, default=3, help='poll interval (s)')
+    ap.add_argument('--min-profit-usd', type=float, default=1.0)
+    ap.add_argument('--max-arb-weth', type=int, default=10**18)  # 1 WETH cap per attempt
+    args = ap.parse_args()
+
+    with open(args.config) as f:
+        cfg = json.load(f)
+    log_file = cfg.get('log_file', f'/tmp/arb_{cfg.get("bot_name", "bot")}.log')
+    heartbeat = cfg.get('heartbeat_file', f'/tmp/arb_{cfg.get("bot_name", "bot")}_hb.log')
+    pid_file = cfg.get('pid_file', f'/tmp/arb_{cfg.get("bot_name", "bot")}.pid')
+    with open(pid_file, 'w') as f:
+        f.write(str(os.getpid()))
+
+    w3_l1 = Web3(Web3.HTTPProvider(cfg['l1_rpc']))
+    w3_proxy = Web3(Web3.HTTPProvider(cfg['l1_proxy']))
+    acct = Account.from_key(cfg['test_key'])
+
+    for k in ('arb_contract', 'weth_l1', 'amm_l1', 'amm_l2'):
+        cfg[k] = Web3.to_checksum_address(cfg[k])
+
+    amm_abi = [
+        {"inputs": [], "name": "reserveA", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+        {"inputs": [], "name": "reserveB", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    ]
+    erc20_abi = [
+        {"inputs": [{"type": "address"}], "name": "balanceOf", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    ]
+    arb_abi = [
+        {"inputs": [{"type": "uint256"}, {"type": "uint256"}], "name": "arbSellOnL1", "outputs": [{"type": "uint256"}], "stateMutability": "nonpayable", "type": "function"},
+        {"inputs": [{"type": "uint256"}, {"type": "uint256"}], "name": "arbSellOnL2", "outputs": [{"type": "uint256"}], "stateMutability": "nonpayable", "type": "function"},
+    ]
+    w3_l2 = Web3(Web3.HTTPProvider(cfg['l2_rpc']))
+    amm_l1 = w3_l1.eth.contract(address=cfg['amm_l1'], abi=amm_abi)
+    amm_l2 = w3_l2.eth.contract(address=cfg['amm_l2'], abi=amm_abi)
+    weth_l1 = w3_l1.eth.contract(address=cfg['weth_l1'], abi=erc20_abi)
+    arb = w3_l1.eth.contract(address=cfg['arb_contract'], abi=arb_abi)
+
+    gas_price = w3_l1.eth.gas_price
+    bot_name = cfg.get('bot_name', 'bot')
+    log(f'=== ARB BOT [{bot_name}] START duration={args.duration}s ===', log_file)
+
+    state = {
+        'iterations': 0, 'opportunities': 0, 'attempts': 0,
+        'successes': 0, 'failures': 0, 'timeouts': 0,
+        'total_profit_weth': 0, 'total_gas_used': 0,
+        'start_time': time.time(),
+    }
+    end = time.time() + args.duration
+
+    while time.time() < end:
+        state['iterations'] += 1
+        try:
+            l1w = amm_l1.functions.reserveA().call()
+            l1u = amm_l1.functions.reserveB().call()
+            l2w = amm_l2.functions.reserveA().call()
+            l2u = amm_l2.functions.reserveB().call()
+            bal = weth_l1.functions.balanceOf(cfg['arb_contract']).call()
+            max_amt = min(bal, args.max_arb_weth)
+            if max_amt < 10**15:
+                time.sleep(args.poll)
+                continue
+
+            p_l1 = l1u / (l1w / 1e18) if l1w else 0
+            p_l2 = l2u / (l2w / 1e18) if l2w else 0
+            p_avg = max(p_l1, p_l2)
+            direction, amount, profit_wei = find_optimal_arb(l1w, l1u, l2w, l2u, max_amt)
+            profit_usd = (profit_wei / 1e18) * (p_avg / 1e6)
+
+            with open(heartbeat, 'w') as f:
+                ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+                f.write(f'{ts} iter={state["iterations"]} L1={p_l1/1e6:.2f} L2={p_l2/1e6:.2f} '
+                        f'best=${profit_usd:+.2f} ({direction or "none"})\n')
+
+            if direction is None or profit_usd < args.min_profit_usd:
+                time.sleep(args.poll)
+                continue
+
+            state['opportunities'] += 1
+            log(f'OPPORTUNITY dir={direction} amount={amount/1e18:.6f}WETH '
+                f'expected=${profit_usd:.2f}', log_file)
+
+            min_profit = int(profit_wei * 80 // 100)
+            fn = 'arbSellOnL1' if direction == 'l1' else 'arbSellOnL2'
+            state['attempts'] += 1
+            try:
+                tx = arb.functions[fn](amount, min_profit).build_transaction({
+                    'from': acct.address,
+                    'nonce': w3_proxy.eth.get_transaction_count(acct.address),
+                    'gas': 5_000_000,
+                    'gasPrice': gas_price,
+                    'chainId': w3_proxy.eth.chain_id,
+                })
+                signed = acct.sign_transaction(tx)
+                tx_hash = w3_proxy.eth.send_raw_transaction(signed.raw_transaction)
+                try:
+                    rcpt = w3_l1.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+                    if rcpt['status'] == 1:
+                        new_bal = weth_l1.functions.balanceOf(cfg['arb_contract']).call()
+                        actual = new_bal - bal
+                        state['successes'] += 1
+                        state['total_gas_used'] += rcpt['gasUsed']
+                        state['total_profit_weth'] += actual
+                        log(f'SUCCESS tx={tx_hash.hex()} gas={rcpt["gasUsed"]} '
+                            f'profit={actual/1e18:.6f}WETH', log_file)
+                    else:
+                        state['failures'] += 1
+                        log(f'REVERTED tx={tx_hash.hex()} gas={rcpt["gasUsed"]}', log_file)
+                except Exception as e:
+                    state['timeouts'] += 1
+                    log(f'TIMEOUT tx={tx_hash.hex()} err={type(e).__name__}: {e}', log_file)
+            except Exception as e:
+                state['failures'] += 1
+                log(f'SEND_ERROR {type(e).__name__}: {e}', log_file)
+
+            if state['iterations'] % 10 == 0:
+                print(json.dumps({'bot': bot_name, **state}), flush=True)
+        except KeyboardInterrupt:
+            break
+        except Exception as e:
+            log(f'LOOP_ERROR {type(e).__name__}: {e}', log_file)
+        time.sleep(args.poll)
+
+    elapsed = time.time() - state['start_time']
+    state['elapsed'] = elapsed
+    log(f'=== DONE elapsed={elapsed:.0f}s iter={state["iterations"]} '
+        f'opps={state["opportunities"]} ok={state["successes"]} '
+        f'fail={state["failures"]} timeout={state["timeouts"]} ===', log_file)
+    print(json.dumps({'bot': bot_name, 'final': True, **state}), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/e2e/arb-soak/monitor.py
+++ b/scripts/e2e/arb-soak/monitor.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Soak monitor — samples the health endpoint, parses bot logs, and emits a
+pass/fail verdict as JSON.
+
+Pass criteria (all must hold):
+- healthy == true at >=95% of samples
+- consecutive_rewind_cycles never exceeds MAX_FLUSH_MISMATCHES (2)
+- L2-L1 lag stays <= L2_LAG_BUDGET (default 20 blocks)
+- no mode oscillation Builder<->Sync more than 3x in any 60s window
+- cross-chain tx success rate across both bots >= SUCCESS_FLOOR_PCT after
+  a warmup window (default 60s)
+- no "anchor-block divergence ... halting" ERROR in builder logs (if we
+  can read them — this is best-effort, skipped when docker isn't available)
+
+Writes {--out} as JSON on exit.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import deque
+from urllib.request import urlopen
+from urllib.error import URLError
+
+
+def sample_health(url, timeout=5):
+    try:
+        with urlopen(url, timeout=timeout) as r:
+            return json.loads(r.read().decode())
+    except (URLError, OSError, ValueError) as e:
+        return {'_error': str(e)}
+
+
+def read_bot_log(path):
+    try:
+        with open(path) as f:
+            return f.read()
+    except FileNotFoundError:
+        return ''
+
+
+def count_events(text):
+    success = len(re.findall(r'^\S+Z SUCCESS ', text, re.M))
+    reverted = len(re.findall(r'^\S+Z REVERTED ', text, re.M))
+    timeout = len(re.findall(r'^\S+Z TIMEOUT ', text, re.M))
+    send_err = len(re.findall(r'^\S+Z SEND_ERROR ', text, re.M))
+    attempts = len(re.findall(r'^\S+Z OPPORTUNITY ', text, re.M))
+    return {'success': success, 'reverted': reverted, 'timeout': timeout,
+            'send_error': send_err, 'opportunities': attempts}
+
+
+def try_grep_builder_logs(docker_compose_cmd, pattern):
+    if not docker_compose_cmd:
+        return None
+    try:
+        out = subprocess.check_output(
+            f'{docker_compose_cmd} logs --since 1h builder 2>/dev/null | grep -c -E "{pattern}" || echo 0',
+            shell=True, text=True, timeout=30)
+        return int(out.strip() or 0)
+    except (subprocess.SubprocessError, ValueError):
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--health-url', required=True)
+    ap.add_argument('--duration', type=int, default=600)
+    ap.add_argument('--interval', type=int, default=5)
+    ap.add_argument('--out', default='/tmp/soak-verdict.json')
+    ap.add_argument('--warmup-s', type=int, default=60)
+    ap.add_argument('--l2-lag-budget', type=int, default=20)
+    ap.add_argument('--max-rewind-cycles', type=int, default=2)
+    ap.add_argument('--success-floor-pct', type=float, default=5.0,
+                    help='min %% of attempts that must succeed after warmup')
+    ap.add_argument('--bot-logs', nargs='+', default=['/tmp/arb_bot.log', '/tmp/arb_bot2.log'])
+    ap.add_argument('--docker-compose-cmd', default='',
+                    help='e.g. "sudo docker compose -f ... -f ..."')
+    args = ap.parse_args()
+
+    start = time.time()
+    end = start + args.duration
+    samples = []
+    mode_changes = deque()  # (timestamp, mode)
+    last_mode = None
+    violations = []
+
+    print(f'[monitor] duration={args.duration}s interval={args.interval}s '
+          f'health_url={args.health_url}', flush=True)
+
+    while time.time() < end:
+        now = time.time()
+        h = sample_health(args.health_url)
+        h['ts'] = now
+        samples.append(h)
+        if '_error' not in h:
+            mode = h.get('mode')
+            if mode and mode != last_mode:
+                mode_changes.append((now, mode))
+                last_mode = mode
+            # sliding 60s window for mode oscillation
+            while mode_changes and now - mode_changes[0][0] > 60:
+                mode_changes.popleft()
+            if len(mode_changes) > 6:  # >3 oscillations (= 6 transitions) in 60s
+                violations.append(
+                    f'{now:.0f}: mode oscillation Builder<->Sync '
+                    f'{len(mode_changes)} transitions in 60s')
+
+            lag = h.get('l1_derivation_head', 0) - h.get('l2_head', 0)
+            if lag > args.l2_lag_budget:
+                violations.append(
+                    f'{now:.0f}: L2 lag {lag} exceeds budget {args.l2_lag_budget}')
+
+            cycles = h.get('consecutive_rewind_cycles', 0)
+            if cycles > args.max_rewind_cycles:
+                violations.append(
+                    f'{now:.0f}: consecutive_rewind_cycles={cycles} '
+                    f'> max {args.max_rewind_cycles}')
+
+        if int(now - start) % 30 == 0 and '_error' not in h:
+            print(
+                f'[{int(now-start):4d}s] mode={h.get("mode")} '
+                f'L2={h.get("l2_head")} L1={h.get("l1_derivation_head")} '
+                f'lag={h.get("l1_derivation_head",0)-h.get("l2_head",0)} '
+                f'cycles={h.get("consecutive_rewind_cycles")} '
+                f'pending={h.get("pending_submissions")} '
+                f'healthy={h.get("healthy")}',
+                flush=True)
+        time.sleep(args.interval)
+
+    # Post-process
+    healthy = [s for s in samples if '_error' not in s and s.get('healthy')]
+    healthy_pct = 100.0 * len(healthy) / max(1, len([s for s in samples if '_error' not in s]))
+    if healthy_pct < 95:
+        violations.append(f'healthy% = {healthy_pct:.1f}% < 95%')
+
+    # Bot events
+    bot_counts = {}
+    for p in args.bot_logs:
+        text = read_bot_log(p)
+        bot_counts[os.path.basename(p)] = count_events(text)
+
+    total_attempts = sum(b.get('opportunities', 0) for b in bot_counts.values())
+    total_success = sum(b.get('success', 0) for b in bot_counts.values())
+    success_rate = 100.0 * total_success / max(1, total_attempts)
+    if total_attempts >= 10 and success_rate < args.success_floor_pct:
+        violations.append(
+            f'cross-chain success rate {success_rate:.1f}% < floor '
+            f'{args.success_floor_pct}% (over {total_attempts} attempts)')
+
+    # Builder log grep (best-effort)
+    halt_count = try_grep_builder_logs(
+        args.docker_compose_cmd,
+        'anchor-block divergence beyond safety threshold|anchor-block post-commit divergence')
+    if halt_count is not None and halt_count > 0:
+        violations.append(f'builder logs contain {halt_count} halt ERROR lines')
+
+    verdict = {
+        'passed': len(violations) == 0,
+        'violations': violations,
+        'duration_s': args.duration,
+        'samples': len(samples),
+        'healthy_pct': healthy_pct,
+        'bot_counts': bot_counts,
+        'total_attempts': total_attempts,
+        'total_success': total_success,
+        'success_rate_pct': success_rate,
+        'halt_log_lines': halt_count,
+        'final_sample': samples[-1] if samples else None,
+    }
+    with open(args.out, 'w') as f:
+        json.dump(verdict, f, indent=2)
+    print(f'\n[monitor] VERDICT: {"PASS" if verdict["passed"] else "FAIL"}', flush=True)
+    for v in violations:
+        print(f'  - {v}', flush=True)
+    print(f'[monitor] written to {args.out}', flush=True)
+    sys.exit(0 if verdict['passed'] else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/e2e/arb-soak/run.sh
+++ b/scripts/e2e/arb-soak/run.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# run.sh — End-to-end soak test orchestrator.
+#
+# Deploys the arb stack (setup.sh), runs 2 arb bots + 1 trader concurrently
+# for SOAK_DURATION seconds, monitors health + bot logs, and exits 0/1 based
+# on the pass/fail verdict in /tmp/soak-verdict.json.
+#
+# Environment:
+#   SOAK_DURATION  seconds to run after setup completes (default 600 = 10 min)
+#   SOAK_SKIP_SETUP=1  reuse existing /tmp/arb_config{,_2}.json (skip setup.sh)
+#   L1_RPC, L1_PROXY, L2_RPC, HEALTH_URL — per lib-health-check.sh conventions.
+#
+# Usage:
+#   ./scripts/e2e/arb-soak/run.sh                             # testnet (default ports)
+#   HEALTH_URL=http://localhost:11560/health \
+#     L1_RPC=http://localhost:11555 \
+#     L1_PROXY=http://localhost:11556 \
+#     L2_RPC=http://localhost:11545 \
+#     SOAK_DURATION=1800 \
+#     ./scripts/e2e/arb-soak/run.sh                           # devnet, 30 min
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib-health-check.sh
+source "$SCRIPT_DIR/../lib-health-check.sh"
+
+SOAK_DURATION="${SOAK_DURATION:-600}"
+VERDICT_FILE="${VERDICT_FILE:-/tmp/soak-verdict.json}"
+SKIP_SETUP="${SOAK_SKIP_SETUP:-0}"
+VENV_DIR="${VENV_DIR:-/tmp/soak-venv}"
+
+# Bootstrap a dedicated venv with web3/eth-account so we don't touch the system
+# Python (PEP 668). Reused across runs.
+if [ ! -x "$VENV_DIR/bin/python3" ]; then
+    python3 -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/pip" install --quiet --upgrade pip
+    "$VENV_DIR/bin/pip" install --quiet 'web3>=6' 'eth-account>=0.10'
+fi
+PY="$VENV_DIR/bin/python3"
+
+blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+
+cleanup() {
+    set +e
+    for p in /tmp/arb_bot.pid /tmp/arb_bot2.pid /tmp/trader.pid; do
+        if [ -f "$p" ]; then
+            kill "$(cat "$p")" 2>/dev/null
+        fi
+    done
+    # Give them a few seconds to flush final JSON lines
+    sleep 2
+}
+trap cleanup EXIT
+
+if [ "$SKIP_SETUP" = "0" ]; then
+    blue "=== [1/4] Setup ==="
+    bash "$SCRIPT_DIR/setup.sh"
+else
+    blue "=== [1/4] Setup (SKIPPED — reusing /tmp/arb_config{,_2}.json) ==="
+fi
+
+[ -f /tmp/arb_config.json ]   || { red "missing /tmp/arb_config.json"; exit 1; }
+[ -f /tmp/arb_config_2.json ] || { red "missing /tmp/arb_config_2.json"; exit 1; }
+
+# Truncate previous bot log files so monitor.py counts only this run
+: > /tmp/arb_bot.log
+: > /tmp/arb_bot2.log
+: > /tmp/trader.log
+
+blue "=== [2/4] Launch bots + trader (duration=${SOAK_DURATION}s) ==="
+"$PY" "$SCRIPT_DIR/bot.py" /tmp/arb_config.json   --duration "$SOAK_DURATION" \
+    > /tmp/arb_bot.stdout  2> /tmp/arb_bot.stderr  &
+BOT1_PID=$!
+"$PY" "$SCRIPT_DIR/bot.py" /tmp/arb_config_2.json --duration "$SOAK_DURATION" \
+    > /tmp/arb_bot2.stdout 2> /tmp/arb_bot2.stderr &
+BOT2_PID=$!
+"$PY" "$SCRIPT_DIR/trader.py" --duration "$SOAK_DURATION" \
+    > /tmp/trader.stdout   2> /tmp/trader.stderr  &
+TRADER_PID=$!
+green "  bot1=pid:$BOT1_PID  bot2=pid:$BOT2_PID  trader=pid:$TRADER_PID"
+
+blue "=== [3/4] Monitor (duration=${SOAK_DURATION}s) ==="
+MONITOR_EXTRA=()
+if [ -n "${DOCKER_COMPOSE_CMD:-}" ]; then
+    MONITOR_EXTRA+=(--docker-compose-cmd "$DOCKER_COMPOSE_CMD")
+fi
+set +e
+"$PY" "$SCRIPT_DIR/monitor.py" \
+    --health-url "$HEALTH_URL" \
+    --duration "$SOAK_DURATION" \
+    --out "$VERDICT_FILE" \
+    "${MONITOR_EXTRA[@]}"
+VERDICT_EXIT=$?
+set -e
+
+wait "$BOT1_PID"   2>/dev/null || true
+wait "$BOT2_PID"   2>/dev/null || true
+wait "$TRADER_PID" 2>/dev/null || true
+
+blue "=== [4/4] Verdict ==="
+if [ "$VERDICT_EXIT" = "0" ]; then
+    green "PASS — see $VERDICT_FILE"
+else
+    red "FAIL — see $VERDICT_FILE"
+fi
+cat "$VERDICT_FILE" | python3 -m json.tool | head -30
+exit "$VERDICT_EXIT"

--- a/scripts/e2e/arb-soak/setup.sh
+++ b/scripts/e2e/arb-soak/setup.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# setup.sh — Deploy the arb-soak stack (adapted from PR #33's deploy_arb_eez.sh).
+#
+# Deploys on a running devnet or testnet:
+#   - L1 MockERC20 WETH + USDC (mints liquidity to the funder)
+#   - L1 SimpleAMM seeded 100 WETH / 300k USDC
+#   - Bridges wrap to discover L2 token addresses
+#   - L2 SimpleAMM seeded with bridged liquidity
+#   - L2Executor + its cross-chain proxy on L1
+#   - Two CrossChainArb contracts (one per bot operator), each funded 1 WETH
+#   - Writes /tmp/arb_config.json and /tmp/arb_config_2.json
+#
+# Endpoints are taken from lib-health-check.sh. Funder is dev#9 per CLAUDE.md.
+# Bot operator keys are unique to this harness; they are NOT in the CLAUDE.md
+# shared dev#N allocation, so this script is safe to run concurrently with
+# the existing E2E tests (bridge-health-check, crosschain-health-check, etc.).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib-health-check.sh
+source "$SCRIPT_DIR/../lib-health-check.sh"
+
+CONTRACTS_DIR="$(cd "$SCRIPT_DIR/../../../contracts/test-multi-call" && pwd)"
+
+# Auto-load contract addresses from the running builder's /shared/rollup.env
+# (same pattern as bridge-health-check.sh:51-58). Falls back to testnet
+# defaults if neither the shared volume nor the builder container is reachable.
+if [ -z "${BRIDGE_L2_ADDRESS:-}" ]; then
+    if [ -f "/shared/rollup.env" ]; then
+        eval "$(cat /shared/rollup.env)"
+    elif [ -n "${SHARED_DIR:-}" ] && [ -f "${SHARED_DIR}/rollup.env" ]; then
+        eval "$(cat "${SHARED_DIR}/rollup.env")"
+    else
+        # Try both devnet and testnet builder containers.
+        for CTR in devnet-eez-builder-1 testnet-eez-builder-1; do
+            env=$(sudo docker exec "$CTR" cat /shared/rollup.env 2>/dev/null || true)
+            if [ -n "$env" ]; then eval "$env"; break; fi
+        done
+    fi
+fi
+ROLLUPS="${ROLLUPS_ADDRESS:-0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512}"
+BRIDGE="${BRIDGE_ADDRESS:-0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9}"
+BRIDGE_L2="${BRIDGE_L2_ADDRESS:-0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0}"
+ROLLUP_ID="${ROLLUP_ID:-1}"
+
+FUNDER_KEY="${FUNDER_KEY:-0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6}"  # dev#9
+FUNDER="$(cast wallet address --private-key "$FUNDER_KEY")"
+if [ "${FUNDER,,}" = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266" ]; then
+    printf '\033[0;31mREFUSING to run with dev#0 (builder/deployer key) as funder — this halts L2.\033[0m\n' >&2
+    exit 1
+fi
+
+# Bot operator keys — unique to this harness, not in CLAUDE.md's dev#N allocation.
+BOT1_KEY="${BOT1_KEY:-0x4fff4c1f39910ff9722e4257a8ae58f92b93b5e31ecad4c74d0628b97ec793d3}"
+BOT1="$(cast wallet address --private-key "$BOT1_KEY")"
+BOT2_KEY="${BOT2_KEY:-0xeaa861a9a01391ed3d587d8a5a84ca56ee277629a8b02c22093a419bf240e65d}"
+BOT2="$(cast wallet address --private-key "$BOT2_KEY")"
+
+CO="--legacy --gas-price 1000000000"
+CO_LONG="--legacy --gas-price 1000000000 --timeout 300"
+
+LIQ_WETH="100000000000000000000"     # 100 WETH
+LIQ_USDC="300000000000"              # 300k USDC (6 decimals)
+ARB_CAPITAL="1000000000000000000"    # 1 WETH per bot
+DEV_FUND_ETH="10000000000000000000"  # 10 ETH gas money per bot
+MINT_WETH="400000000000000000000"    # 400 WETH minted to funder
+MINT_USDC="900000000000"             # 900k USDC minted to funder
+
+blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+
+fcreate() {
+    local rpc="$1" key="$2" contract="$3"; shift 3
+    forge create $CO --rpc-url "$rpc" --private-key "$key" --broadcast \
+        --root "$CONTRACTS_DIR" "$contract" "$@" 2>&1 \
+        | grep "Deployed to:" | awk '{print $3}'
+}
+
+send() {
+    local rpc="$1" key="$2" to="$3" sig="$4"; shift 4
+    cast send $CO --rpc-url "$rpc" --private-key "$key" "$to" "$sig" "$@" \
+        --gas-limit 1500000 > /dev/null
+}
+
+blue "=== arb-soak setup ==="
+blue "  L1_RPC    = $L1_RPC"
+blue "  L1_PROXY  = $L1_PROXY"
+blue "  L2_RPC    = $L2_RPC"
+blue "  HEALTH    = $HEALTH_URL"
+
+blue "=== Compile contracts ==="
+(cd "$CONTRACTS_DIR" && forge build > /dev/null 2>&1) || { red "compile failed"; exit 1; }
+green "  ok"
+
+blue "=== Fund bot operators ==="
+for op in "$BOT1" "$BOT2"; do
+    cast send $CO --rpc-url "$L1_RPC" --private-key "$FUNDER_KEY" \
+        --value "$DEV_FUND_ETH" "$op" --gas-limit 50000 > /dev/null
+    green "  $op funded 10 ETH on L1"
+done
+
+blue "=== Deploy L1 tokens ==="
+WETH_L1=$(fcreate "$L1_RPC" "$FUNDER_KEY" "src/MockERC20.sol:MockERC20" \
+    --constructor-args "Wrapped Ether" "WETH" 18)
+USDC_L1=$(fcreate "$L1_RPC" "$FUNDER_KEY" "src/MockERC20.sol:MockERC20" \
+    --constructor-args "USD Coin" "USDC" 6)
+[ -n "$WETH_L1" ] && [ -n "$USDC_L1" ] || { red "token deploy failed"; exit 1; }
+green "  WETH_L1: $WETH_L1"
+green "  USDC_L1: $USDC_L1"
+
+blue "=== Mint L1 tokens to funder ==="
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "mint(address,uint256)" "$FUNDER" "$MINT_WETH"
+send "$L1_RPC" "$FUNDER_KEY" "$USDC_L1" "mint(address,uint256)" "$FUNDER" "$MINT_USDC"
+green "  minted 400 WETH / 900k USDC"
+
+blue "=== Deploy L1 SimpleAMM and seed liquidity ==="
+AMM_L1=$(fcreate "$L1_RPC" "$FUNDER_KEY" "src/SimpleAMM.sol:SimpleAMM" \
+    --constructor-args "$WETH_L1" "$USDC_L1")
+[ -n "$AMM_L1" ] || { red "AMM_L1 deploy failed"; exit 1; }
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "approve(address,uint256)" "$AMM_L1" "$LIQ_WETH"
+send "$L1_RPC" "$FUNDER_KEY" "$USDC_L1" "approve(address,uint256)" "$AMM_L1" "$LIQ_USDC"
+send "$L1_RPC" "$FUNDER_KEY" "$AMM_L1" "addLiquidity(uint256,uint256)" "$LIQ_WETH" "$LIQ_USDC"
+green "  AMM_L1: $AMM_L1  seeded 100 WETH / 300k USDC"
+
+blue "=== Bridge WETH and USDC to L2 ==="
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "approve(address,uint256)" "$BRIDGE" "$LIQ_WETH"
+send "$L1_RPC" "$FUNDER_KEY" "$USDC_L1" "approve(address,uint256)" "$BRIDGE" "$LIQ_USDC"
+cast send $CO_LONG --rpc-url "$L1_PROXY" --private-key "$FUNDER_KEY" "$BRIDGE" \
+    "bridgeTokens(address,uint256,uint256,address)" "$WETH_L1" "$LIQ_WETH" "$ROLLUP_ID" "$FUNDER" \
+    --gas-limit 1500000 > /dev/null
+cast send $CO_LONG --rpc-url "$L1_PROXY" --private-key "$FUNDER_KEY" "$BRIDGE" \
+    "bridgeTokens(address,uint256,uint256,address)" "$USDC_L1" "$LIQ_USDC" "$ROLLUP_ID" "$FUNDER" \
+    --gas-limit 1500000 > /dev/null
+green "  bridge txs sent"
+
+blue "=== Bridge ETH to funder on L2 (for gas to deploy L2 contracts) ==="
+# Without this, `forge create` on L2 fails with "gas required exceeds allowance".
+# dev#9 has no L2 ETH by default; bridge a small amount before L2 deploys.
+L2_GAS_ETH="5000000000000000000"  # 5 ETH
+FUNDER_L2_BAL=$(cast balance --rpc-url "$L2_RPC" "$FUNDER" 2>/dev/null || echo "0")
+if [ "${FUNDER_L2_BAL:-0}" -lt "$L2_GAS_ETH" ] 2>/dev/null; then
+    cast send $CO --rpc-url "$L1_PROXY" --private-key "$FUNDER_KEY" \
+        --value "$L2_GAS_ETH" --gas-limit 1500000 \
+        "$BRIDGE" "bridgeEther(uint256,address)" "$ROLLUP_ID" "$FUNDER" > /dev/null
+    green "  bridged 5 ETH to dev#9 on L2"
+else
+    green "  funder already has $((FUNDER_L2_BAL / 1000000000000000000)) ETH on L2"
+fi
+
+blue "=== Wait for L2 wrapped-token delivery ==="
+WETH_L2=""
+USDC_L2=""
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    sleep 3
+    WETH_L2=$(cast call --rpc-url "$L2_RPC" "$BRIDGE_L2" \
+        "getWrappedToken(address,uint256)(address)" "$WETH_L1" 0 2>/dev/null || true)
+    USDC_L2=$(cast call --rpc-url "$L2_RPC" "$BRIDGE_L2" \
+        "getWrappedToken(address,uint256)(address)" "$USDC_L1" 0 2>/dev/null || true)
+    if [ -n "$WETH_L2" ] && [ -n "$USDC_L2" ] \
+       && [ "$WETH_L2" != "0x0000000000000000000000000000000000000000" ] \
+       && [ "$USDC_L2" != "0x0000000000000000000000000000000000000000" ]; then
+        wbal=$(cast call --rpc-url "$L2_RPC" "$WETH_L2" "balanceOf(address)(uint256)" "$FUNDER" 2>/dev/null | awk '{print $1}')
+        ubal=$(cast call --rpc-url "$L2_RPC" "$USDC_L2" "balanceOf(address)(uint256)" "$FUNDER" 2>/dev/null | awk '{print $1}')
+        if [ "${wbal:-0}" -ge "$LIQ_WETH" ] 2>/dev/null && [ "${ubal:-0}" -ge "$LIQ_USDC" ] 2>/dev/null; then
+            break
+        fi
+    fi
+    blue "  waiting for bridge delivery... ($i/15)"
+done
+[ -n "$WETH_L2" ] && [ "$WETH_L2" != "0x0000000000000000000000000000000000000000" ] || { red "WETH_L2 not delivered"; exit 1; }
+[ -n "$USDC_L2" ] && [ "$USDC_L2" != "0x0000000000000000000000000000000000000000" ] || { red "USDC_L2 not delivered"; exit 1; }
+green "  WETH_L2: $WETH_L2"
+green "  USDC_L2: $USDC_L2"
+
+blue "=== Deploy L2 SimpleAMM and seed liquidity ==="
+AMM_L2=$(fcreate "$L2_RPC" "$FUNDER_KEY" "src/SimpleAMM.sol:SimpleAMM" \
+    --constructor-args "$WETH_L2" "$USDC_L2")
+[ -n "$AMM_L2" ] || { red "AMM_L2 deploy failed"; exit 1; }
+send "$L2_RPC" "$FUNDER_KEY" "$WETH_L2" "approve(address,uint256)" "$AMM_L2" "$LIQ_WETH"
+send "$L2_RPC" "$FUNDER_KEY" "$USDC_L2" "approve(address,uint256)" "$AMM_L2" "$LIQ_USDC"
+send "$L2_RPC" "$FUNDER_KEY" "$AMM_L2" "addLiquidity(uint256,uint256)" "$LIQ_WETH" "$LIQ_USDC"
+green "  AMM_L2: $AMM_L2"
+
+blue "=== Deploy L2Executor + its cross-chain proxy ==="
+L2_EXEC=$(fcreate "$L2_RPC" "$FUNDER_KEY" "src/L2Executor.sol:L2Executor" \
+    --constructor-args "$AMM_L2" "$BRIDGE_L2" "$WETH_L2" "$USDC_L2")
+[ -n "$L2_EXEC" ] || { red "L2Executor deploy failed"; exit 1; }
+send "$L1_RPC" "$FUNDER_KEY" "$ROLLUPS" "createCrossChainProxy(address,uint256)" "$L2_EXEC" "$ROLLUP_ID"
+L2_EXEC_PROXY=$(cast call --rpc-url "$L1_RPC" "$ROLLUPS" \
+    "computeCrossChainProxyAddress(address,uint256)(address)" "$L2_EXEC" "$ROLLUP_ID" 2>/dev/null)
+green "  L2_EXEC: $L2_EXEC"
+green "  L2_EXEC_PROXY: $L2_EXEC_PROXY"
+
+blue "=== Deploy CrossChainArb contracts ==="
+ARB1=$(fcreate "$L1_RPC" "$BOT1_KEY" "src/CrossChainArb.sol:CrossChainArb" \
+    --constructor-args "$WETH_L1" "$USDC_L1" "$AMM_L1" "$BRIDGE" "$ROLLUP_ID")
+[ -n "$ARB1" ] || { red "ARB1 deploy failed"; exit 1; }
+send "$L1_RPC" "$BOT1_KEY" "$ARB1" "setL2Executor(address,address)" "$L2_EXEC" "$L2_EXEC_PROXY"
+green "  ARB1: $ARB1"
+ARB2=$(fcreate "$L1_RPC" "$BOT2_KEY" "src/CrossChainArb.sol:CrossChainArb" \
+    --constructor-args "$WETH_L1" "$USDC_L1" "$AMM_L1" "$BRIDGE" "$ROLLUP_ID")
+[ -n "$ARB2" ] || { red "ARB2 deploy failed"; exit 1; }
+send "$L1_RPC" "$BOT2_KEY" "$ARB2" "setL2Executor(address,address)" "$L2_EXEC" "$L2_EXEC_PROXY"
+green "  ARB2: $ARB2"
+
+blue "=== Fund arb contracts with WETH working capital ==="
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "mint(address,uint256)" "$ARB1" "$ARB_CAPITAL"
+send "$L1_RPC" "$FUNDER_KEY" "$WETH_L1" "mint(address,uint256)" "$ARB2" "$ARB_CAPITAL"
+green "  each arb funded with 1 WETH"
+
+blue "=== Write configs ==="
+write_cfg() {
+    local path="$1" name="$2" key="$3" addr="$4" arb="$5" log="$6" hb="$7" pid="$8"
+    cat > "$path" <<EOF
+{
+  "l1_rpc": "$L1_RPC",
+  "l1_proxy": "$L1_PROXY",
+  "l2_rpc": "$L2_RPC",
+  "weth_l1": "$WETH_L1",
+  "usdc_l1": "$USDC_L1",
+  "amm_l1": "$AMM_L1",
+  "weth_l2": "$WETH_L2",
+  "usdc_l2": "$USDC_L2",
+  "amm_l2": "$AMM_L2",
+  "bridge": "$BRIDGE",
+  "l2_executor": "$L2_EXEC",
+  "l2_executor_proxy": "$L2_EXEC_PROXY",
+  "bot_name": "$name",
+  "test_key": "$key",
+  "test_addr": "$addr",
+  "arb_contract": "$arb",
+  "log_file": "$log",
+  "heartbeat_file": "$hb",
+  "pid_file": "$pid"
+}
+EOF
+}
+write_cfg /tmp/arb_config.json   bot1 "$BOT1_KEY" "$BOT1" "$ARB1" /tmp/arb_bot.log  /tmp/arb_bot_heartbeat.log  /tmp/arb_bot.pid
+write_cfg /tmp/arb_config_2.json bot2 "$BOT2_KEY" "$BOT2" "$ARB2" /tmp/arb_bot2.log /tmp/arb_bot2_heartbeat.log /tmp/arb_bot2.pid
+green "  /tmp/arb_config.json"
+green "  /tmp/arb_config_2.json"
+
+green ""
+green "=== Deploy complete ==="
+echo "ARB1=$ARB1  ARB2=$ARB2"
+echo "AMM_L1=$AMM_L1  AMM_L2=$AMM_L2"
+echo "L2_EXEC=$L2_EXEC  proxy=$L2_EXEC_PROXY"

--- a/scripts/e2e/arb-soak/trader.py
+++ b/scripts/e2e/arb-soak/trader.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Random trader — time-bounded variant of PR #33's trader.py.
+
+Creates price movements on the L1 or L2 AMM so arb opportunities exist.
+Uses dev#9 key (funder). Exits after --duration seconds.
+"""
+
+import argparse
+import json
+import math
+import os
+import random
+import time
+from datetime import datetime, timezone
+from web3 import Web3
+from eth_account import Account
+
+TRADER_KEY = '0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6'  # dev#9
+
+AMM_ABI = [
+    {"inputs": [], "name": "reserveA", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "reserveB", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [{"type": "address"}, {"type": "uint256"}], "name": "swap", "outputs": [{"type": "uint256"}], "stateMutability": "nonpayable", "type": "function"},
+]
+ERC20_ABI = [
+    {"inputs": [{"type": "address"}], "name": "balanceOf", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [{"type": "address"}, {"type": "uint256"}], "name": "approve", "outputs": [{"type": "bool"}], "stateMutability": "nonpayable", "type": "function"},
+    {"inputs": [{"type": "address"}, {"type": "uint256"}], "name": "mint", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
+]
+
+
+def log(line, log_file):
+    ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    msg = f'{ts} {line}'
+    print(msg, flush=True)
+    with open(log_file, 'a') as f:
+        f.write(msg + '\n')
+
+
+def trade_size_for_move(reserve_in, pct):
+    k = 1 - pct
+    return int(reserve_in * (1 / math.sqrt(k) - 1))
+
+
+def ensure_balance(w3, erc_abi, token_addr, trader, needed, mintable):
+    erc = w3.eth.contract(address=token_addr, abi=erc_abi)
+    bal = erc.functions.balanceOf(trader.address).call()
+    if bal >= needed:
+        return True
+    if not mintable:
+        return False
+    to_mint = (needed - bal) * 10
+    tx = erc.functions.mint(trader.address, to_mint).build_transaction({
+        'from': trader.address,
+        'nonce': w3.eth.get_transaction_count(trader.address),
+        'gas': 200000,
+        'gasPrice': 2 * 10**9,
+        'chainId': w3.eth.chain_id,
+    })
+    signed = trader.sign_transaction(tx)
+    try:
+        rcpt = w3.eth.wait_for_transaction_receipt(w3.eth.send_raw_transaction(signed.raw_transaction), timeout=60)
+        return rcpt['status'] == 1
+    except Exception:
+        return False
+
+
+def do_trade(cfg, trader, chain, sell_weth, pct):
+    if chain == 'l1':
+        w3 = Web3(Web3.HTTPProvider(cfg['l1_rpc']))
+        w3_send = Web3(Web3.HTTPProvider(cfg['l1_proxy']))
+        amm_addr = cfg['amm_l1']
+        weth_addr = cfg['weth_l1']
+        usdc_addr = cfg['usdc_l1']
+        mintable = True
+    else:
+        w3 = Web3(Web3.HTTPProvider(cfg['l2_rpc']))
+        w3_send = w3
+        amm_addr = cfg['amm_l2']
+        weth_addr = cfg['weth_l2']
+        usdc_addr = cfg['usdc_l2']
+        mintable = False
+
+    amm = w3.eth.contract(address=amm_addr, abi=AMM_ABI)
+    ra = amm.functions.reserveA().call()
+    rb = amm.functions.reserveB().call()
+
+    if sell_weth:
+        token_in = weth_addr
+        amount_in = min(trade_size_for_move(ra, pct), ra // 3)
+    else:
+        token_in = usdc_addr
+        amount_in = min(trade_size_for_move(rb, pct), rb // 3)
+
+    if amount_in == 0:
+        return False, 'zero_amount'
+    if not ensure_balance(w3, ERC20_ABI, token_in, trader, amount_in, mintable):
+        return False, 'insufficient_balance'
+
+    erc = w3.eth.contract(address=token_in, abi=ERC20_ABI)
+    tx = erc.functions.approve(amm_addr, amount_in).build_transaction({
+        'from': trader.address,
+        'nonce': w3_send.eth.get_transaction_count(trader.address),
+        'gas': 100000, 'gasPrice': 2*10**9, 'chainId': w3_send.eth.chain_id,
+    })
+    try:
+        w3.eth.wait_for_transaction_receipt(
+            w3_send.eth.send_raw_transaction(trader.sign_transaction(tx).raw_transaction),
+            timeout=60)
+    except Exception as e:
+        return False, f'approve_failed:{type(e).__name__}'
+
+    tx = amm.functions.swap(token_in, amount_in).build_transaction({
+        'from': trader.address,
+        'nonce': w3_send.eth.get_transaction_count(trader.address),
+        'gas': 500000, 'gasPrice': 2*10**9, 'chainId': w3_send.eth.chain_id,
+    })
+    try:
+        rcpt = w3.eth.wait_for_transaction_receipt(
+            w3_send.eth.send_raw_transaction(trader.sign_transaction(tx).raw_transaction),
+            timeout=60)
+        if rcpt['status'] != 1:
+            return False, 'swap_reverted'
+    except Exception as e:
+        return False, f'swap_failed:{type(e).__name__}'
+
+    ra2 = amm.functions.reserveA().call()
+    rb2 = amm.functions.reserveB().call()
+    p1 = rb / ra if ra else 0
+    p2 = rb2 / ra2 if ra2 else 0
+    move = (p2 - p1) / p1 * 100 if p1 else 0
+    return True, f'{chain} {"sellWETH" if sell_weth else "buyWETH"} move={move:+.2f}%'
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--config', default='/tmp/arb_config.json')
+    ap.add_argument('--duration', type=int, default=600)
+    ap.add_argument('--log', default='/tmp/trader.log')
+    args = ap.parse_args()
+
+    with open(args.config) as f:
+        cfg = json.load(f)
+    for k in ('weth_l1', 'usdc_l1', 'amm_l1', 'amm_l2', 'weth_l2', 'usdc_l2'):
+        cfg[k] = Web3.to_checksum_address(cfg[k])
+    trader = Account.from_key(TRADER_KEY)
+    with open('/tmp/trader.pid', 'w') as f:
+        f.write(str(os.getpid()))
+
+    log(f'=== TRADER START duration={args.duration}s addr={trader.address} ===', args.log)
+    # Bootstrap mintable balances
+    w3_l1 = Web3(Web3.HTTPProvider(cfg['l1_rpc']))
+    ensure_balance(w3_l1, ERC20_ABI, cfg['weth_l1'], trader, 100 * 10**18, True)
+    ensure_balance(w3_l1, ERC20_ABI, cfg['usdc_l1'], trader, 200_000 * 10**6, True)
+
+    trades_ok = 0
+    trades_fail = 0
+    end = time.time() + args.duration
+    while time.time() < end:
+        try:
+            chain = random.choice(['l1', 'l2'])
+            sell_weth = random.choice([True, False])
+            pct = random.uniform(0.005, 0.05)
+            ok, msg = do_trade(cfg, trader, chain, sell_weth, pct)
+            if ok:
+                trades_ok += 1
+                log(f'TRADE {msg}', args.log)
+            else:
+                trades_fail += 1
+                log(f'skip {msg}', args.log)
+        except Exception as e:
+            trades_fail += 1
+            log(f'ERROR {type(e).__name__}: {e}', args.log)
+        time.sleep(random.uniform(5, 20))
+
+    log(f'=== TRADER DONE ok={trades_ok} fail={trades_fail} ===', args.log)
+    print(json.dumps({'trader_ok': trades_ok, 'trader_fail': trades_fail, 'final': True}), flush=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Follow-up to [PR #39](https://github.com/eez-association/sync-rollups-composer/pull/39). A 60-min devnet soak against PR #39 revealed that **55% of Fix 1 recoveries were silently falling through to bare FCU rewind** instead of the sibling-reorg path they claimed to queue. This PR fixes both the proximate cause (verify wiping the queue) and the integration gap (step_builder short-circuiting before dispatch). Empirically validated: 60-min soak now PASSES cleanly with **45/45 recoveries via sibling-reorg + 0 bare FCU**.

## Byte-level forensics that motivated this PR

### Problem 1 — `verify_local_block_matches_l1` wiping Fix 1's queue

PR #39's Fix 1 queues `pending_sibling_reorg` at postBatch confirmation. But `step_builder::derive_and_verify_from_l1` calls `verify_local_block_matches_l1` within the same tick, which:
- Saw `filtering_present && sibling_reorg_already_queued`
- Classifier returned `GenericMismatchRewind` (per old logic)
- Handler called `clear_internal_state()` — **wiping Fix 1's queued request**
- Set `pending_rewind_target` → bare FCU rewind on next tick

PR #39 soak counters (60 min):
```
76  Fix 1 queues
34  flush_precheck dispatches + 34 sibling reorgs   ← lucky timing cases
42  bare FCU rewinds                                 ← silent fallback
 0  rebuild_block_as_sibling on the 42 cases
```

On production reth Ethereum-engine, per §8b and Engine API spec, bare FCU-to-ancestor is a silent no-op → `rewind_l2_chain`'s fallback marks the divergent block `immutable_block_ceiling` → permanent consensus divergence between builder and fullnodes.

### Problem 2 — new livelock from Option B

The naïve fix (new `VerifyMismatchAction::NoOpPendingSiblingReorg` that returns `Err` without state mutation, commits `17f91e4` + `b6ffe06`) introduced a new livelock. Byte-level from 2nd devnet soak:

```
14:01:59.601   Fix 1 queue for block 71
14:01:59.604   NoOp Err fires              ← 3ms later, same tick
14:02:01.609   NoOp Err (+2s backoff)
14:02:05.614   NoOp Err (+4s)
...
14:25:01.747   NoOp Err (+60s, capped)     ← 38 events total, 23 min stuck
```

Root cause: `step_builder.rs:138` calls `derive_and_verify_from_l1(...)?` BEFORE `flush_to_l1()` at line 388. When verify returns `Err` from the NoOp handler, `?` propagates, step_builder short-circuits, `flush_to_l1` never runs, `flush_precheck`'s sibling-reorg dispatch never fires. Chain frozen at L2=71 with `pending_sibling_reorg` sitting idle.

Block 71 builder local: stateRoot `0x8860b859…` (5 txs including speculative CCM tx).
Block 71 fullnode / contract: stateRoot `0x31b4293b…` (4 txs, §4f-filtered). Evidence preserved in `/tmp/builder-option-b-stuck.log`.

## Fix — three commits

### 1. `17f91e4` — classifier preserves queued reorg

Adds `VerifyMismatchAction::NoOpPendingSiblingReorg` that fires when `filtering_present && sibling_reorg_already_queued`. Handler returns `Err` without calling `clear_internal_state` or setting `pending_rewind_target`. Preserves the queued request so `flush_precheck` can dispatch it.

### 2. `b6ffe06` — 8 regression tests

- Group A: state-preservation invariants (queue survives verify)
- Group B: staleness convergence (N queued, then M diverges → converges cleanly)
- Group C: classifier priority (NoOp wins over `DeferEntryVerify` / `ExhaustedDeferralRewind`)
- Group D: idempotency across ticks
- 683 tests pass (default + `--features test-utils`).

### 3. `7298c1b` — break `derive_and_verify` loop on pending sibling reorg

Two-line change in `step_builder.rs` mirroring the existing `pending_rewind_target.is_some()` break: also break on `pending_sibling_reorg.is_some()`, and skip `commit_batch` in that case. Lets `flush_precheck` dispatch the queued reorg on the same tick instead of being short-circuited by verify's `Err`.

## Empirical validation

60-min devnet soak against the arb-bot-contention workload from [PR #33](https://github.com/eez-association/sync-rollups-composer/pull/33), adapted in `scripts/e2e/arb-soak/`.

### Pre-fix (PR #39 alone)
```
violations:      7 (mode-oscillation budget exceeded)
verdict:         FAIL
76 Fix 1 queues → 34 sibling reorgs + 42 bare FCU rewinds (55% silent fallback)
```

### 2nd attempt (Option B only — 17f91e4 + b6ffe06)
```
L2 wedged at block 71 for 23+ min
38 NoOp Err events, 0 dispatches, 0 sibling reorgs
```

### This PR (all three commits)
```
verdict:         PASS
violations:      0
healthy_pct:     100%
rewind cycles:   0
mode flips:      0

Recovery counters (PERFECT 1:1:1:1):
  45  Fix 1 queues
  45  flush_precheck dispatches
  45  sibling reorgs completed (newPayloadV3 + FCU)
  45  "breaking loop" (new step_builder code path)
   0  stuck NoOp Err events
   0  bare FCU rewinds

bot success rate: 52.7%  (69/131 attempts, 17 timeouts)
```

Every Fix 1 trigger resolves via `rebuild_block_as_sibling` + `newPayloadV3`. Zero fall through to bare FCU. Zero livelock signatures.

## Test plan

- [x] `cargo build --release -p based-rollup` — clean
- [x] `cargo clippy --workspace --all-targets --all-features --release -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features test-utils` — 683 tests pass
- [x] `cargo +nightly fmt --all --check` — clean
- [x] 60-min devnet soak under arb-bot-contention workload — PASS verdict, 0 violations
- [ ] Follow-up: handler-side `DriverTestHarness` integration test (requires `seed_local_header` plumbing per test-writer's skeleton at `driver_tests.rs:6300`)
- [ ] Follow-up: soak on reth Ethereum-engine (not `--dev`) to confirm production behavior matches dev

## Audit

Option B handler arm passed consensus-safety audit (PASS, merge-ready, 2 low-severity notes). The new `step_builder` break follows the identical pattern as the existing `pending_rewind_target.is_some()` break — no new state transitions, no new side-effects.

## Relation to PR #39

PR #39 shipped Fix 1 + Fix 2 (anchor-divergence detection). This PR completes the recovery pipeline by ensuring the queued sibling reorg actually runs instead of being silently wiped. Without this PR, PR #39's fix only works on reth `--dev` (by accident); on production Ethereum-engine reth it would introduce permanent consensus divergence between builder and fullnodes.

## Known limitations (not blocking)

1. `rebuild_block_as_sibling` path has now been validated at scale (45 successful rebuilds in the soak). The stale-queue failure mode (rebuild fails repeatedly) is still gated by `REORG_SAFETY_THRESHOLD = 48` but has not been exercised under sustained failure.
2. The `commit` field in the binary still shows the pre-fix hash because vergen bakes git HEAD at build time. Rebuild after this PR merges will fix that.

## References

- PR #33 — arb-bot reproducer (adapted into `scripts/e2e/arb-soak/`)
- PR #39 — Fix 1 + Fix 2 post-commit divergence recovery
- Issue #35 — original L2 rewind loop symptom
- `docs/DERIVATION.md` §8b — sibling-reorg recovery invariants
- `CLAUDE.md` "Sibling Reorg / Post-Commit Divergence Recovery"

🤖 Generated with [Claude Code](https://claude.com/claude-code)