### PR TITLE
fix(composer): bundle queued L1 user txs atomically with postBatch

### DIFF
--- a/crates/based-rollup/src/driver/flush.rs
+++ b/crates/based-rollup/src/driver/flush.rs
@@ -727,6 +727,29 @@ where
         // touching the hold field at all — invariant #1 only applies
         // when there are actual entries).
         let gas_hint = self.compute_gas_overbid();
+        // In bundle mode, drain queued user L1 txs BEFORE submit so they can
+        // ride in the same `eth_sendBundle` as postBatch. Without this, the
+        // post-submit `forward_queued_l1_txs` call later in this function
+        // sends them via `eth_sendRawTransaction` to the public mempool,
+        // where they land in some later block — breaking the contract's
+        // `lastStateUpdateBlock == block.number` invariant in
+        // `executeCrossChainCall` and reverting with
+        // `ExecutionNotInCurrentBlock()`. On submit failure we re-queue them
+        // (see `SendResult::Failed` handling below).
+        //
+        // In raw-RPC mode (e.g., reth --dev) we leave the queue alone — the
+        // builder also drives block production, so the post-submit
+        // `forward_queued_l1_txs` call lands user txs in the same block as
+        // postBatch by construction. Bundling there would be wasted work.
+        let bundled_user_txs: Vec<Bytes> = if proposer.uses_bundle_submission() {
+            let mut q = self
+                .pending_l1_forward_txs
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            q.drain(..).collect()
+        } else {
+            Vec::new()
+        };
         let send_result = if has_entries {
             let plan = FlushPlan::<Collected>::new_collected(blocks, pending_l1_owned)
                 .arm_hold(&mut self.hold);
@@ -734,12 +757,14 @@ where
                 target: "based_rollup::driver",
                 l2_block = ?plan.block_count(),
                 entry_count = plan.entry_count(),
+                bundled_user_tx_count = bundled_user_txs.len(),
                 "setting entry verification hold before L1 submission (§4f nonce safety, FlushPlan<HoldArmed>)"
             );
-            plan.submit_via(proposer, gas_hint).await
+            plan.submit_via(proposer, gas_hint, &bundled_user_txs).await
         } else {
             let plan = FlushPlan::<NoEntries>::new_blocks_only(blocks);
-            plan.submit_via(proposer, gas_hint).await
+            // Blocks-only plans never carry user txs — pass empty.
+            plan.submit_via(proposer, gas_hint, &[]).await
         };
 
         // Unpack the `SendResult` into the legacy `Result<B256>`
@@ -749,6 +774,18 @@ where
         let (send_result, rollback) = match send_result {
             SendResult::Ok { tx_hash } => (Ok::<B256, eyre::Report>(tx_hash), None),
             SendResult::Failed { error, rollback } => {
+                // Submit failed — restore the user txs we drained earlier so
+                // the next flush attempt can include them in its bundle.
+                if !bundled_user_txs.is_empty() {
+                    let mut q = self
+                        .pending_l1_forward_txs
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    // Preserve original order: drained txs go back to the front.
+                    let mut restored = bundled_user_txs.clone();
+                    restored.extend(q.drain(..));
+                    *q = restored;
+                }
                 (Err::<B256, eyre::Report>(error), Some(rollback))
             }
         };

--- a/crates/based-rollup/src/driver/flush.rs
+++ b/crates/based-rollup/src/driver/flush.rs
@@ -727,29 +727,35 @@ where
         // touching the hold field at all — invariant #1 only applies
         // when there are actual entries).
         let gas_hint = self.compute_gas_overbid();
-        // In bundle mode, drain queued user L1 txs BEFORE submit so they can
-        // ride in the same `eth_sendBundle` as postBatch. Without this, the
-        // post-submit `forward_queued_l1_txs` call later in this function
-        // sends them via `eth_sendRawTransaction` to the public mempool,
-        // where they land in some later block — breaking the contract's
-        // `lastStateUpdateBlock == block.number` invariant in
-        // `executeCrossChainCall` and reverting with
-        // `ExecutionNotInCurrentBlock()`. On submit failure we re-queue them
-        // (see `SendResult::Failed` handling below).
+        // Only drain queued user L1 txs when we are about to submit a Collected
+        // plan in bundle mode. Otherwise leave the queue alone:
+        //   - has_entries=false: blocks-only flush, no executeCrossChainCall
+        //     piggybacking. Draining here would silently drop the user tx
+        //     since the NoEntries path passes `&[]` to send_to_l1.
+        //   - raw-RPC mode (reth --dev): post-submit `forward_queued_l1_txs`
+        //     handles them; the proposer also drives block production so they
+        //     land in the same block as postBatch by construction.
         //
-        // In raw-RPC mode (e.g., reth --dev) we leave the queue alone — the
-        // builder also drives block production, so the post-submit
-        // `forward_queued_l1_txs` call lands user txs in the same block as
-        // postBatch by construction. Bundling there would be wasted work.
-        let bundled_user_txs: Vec<Bytes> = if proposer.uses_bundle_submission() {
-            let mut q = self
-                .pending_l1_forward_txs
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            q.drain(..).collect()
-        } else {
-            Vec::new()
-        };
+        // Atomicity rationale (bundle mode + has_entries): forwarded user txs
+        // (e.g. bridgeEther from the L1 composer RPC) MUST share
+        // `(parent_hash, block.timestamp)` with the postBatch. If they enter
+        // public mempool separately they land in a later block and the
+        // contract's `lastStateUpdateBlock == block.number` invariant in
+        // `executeCrossChainCall` reverts with
+        // `ExecutionNotInCurrentBlock()`. Including them in the same
+        // `eth_sendBundle.txs` array makes both land or both drop together.
+        // On submit failure we restore the drained txs to the front of the
+        // queue (see `SendResult::Failed` arm).
+        let bundled_user_txs: Vec<Bytes> =
+            if has_entries && proposer.uses_bundle_submission() {
+                let mut q = self
+                    .pending_l1_forward_txs
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                q.drain(..).collect()
+            } else {
+                Vec::new()
+            };
         let send_result = if has_entries {
             let plan = FlushPlan::<Collected>::new_collected(blocks, pending_l1_owned)
                 .arm_hold(&mut self.hold);
@@ -763,7 +769,6 @@ where
             plan.submit_via(proposer, gas_hint, &bundled_user_txs).await
         } else {
             let plan = FlushPlan::<NoEntries>::new_blocks_only(blocks);
-            // Blocks-only plans never carry user txs — pass empty.
             plan.submit_via(proposer, gas_hint, &[]).await
         };
 

--- a/crates/based-rollup/src/driver/flush_plan.rs
+++ b/crates/based-rollup/src/driver/flush_plan.rs
@@ -11,7 +11,7 @@ use super::pending_queue::PendingL1SubmissionQueue;
 use crate::cross_chain::CrossChainExecutionEntry;
 use crate::driver::hold::EntryVerificationHold;
 use crate::proposer::{GasPriceHint, PendingBlock, Proposer};
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Bytes};
 use std::marker::PhantomData;
 
 // ──────────────────────────────────────────────
@@ -285,12 +285,20 @@ impl<S: Sendable> FlushPlan<S> {
         self,
         proposer: &Proposer,
         gas_hint: Option<GasPriceHint>,
+        // Pre-signed L1 user txs (bridgeEther, etc. forwarded from the L1
+        // composer RPC) to bundle atomically with postBatch in bundle mode.
+        // In raw-RPC mode these are ignored; the caller forwards them
+        // separately. Empty slice if none.
+        bundled_user_txs: &[Bytes],
     ) -> SendResult {
         let Self {
             blocks, pending_l1, ..
         } = self;
         let entries_slice: &[CrossChainExecutionEntry] = &pending_l1.entries;
-        match proposer.send_to_l1(&blocks, entries_slice, gas_hint).await {
+        match proposer
+            .send_to_l1(&blocks, entries_slice, gas_hint, bundled_user_txs)
+            .await
+        {
             Ok(tx_hash) => SendResult::Ok { tx_hash },
             Err(error) => SendResult::Failed {
                 error,

--- a/crates/based-rollup/src/proposer.rs
+++ b/crates/based-rollup/src/proposer.rs
@@ -226,6 +226,15 @@ impl Proposer {
         })
     }
 
+    /// Whether postBatch submission goes through `eth_sendBundle` to a
+    /// builder RPC (true) or through `eth_sendRawTransaction` to the
+    /// public mempool (false). Used by the driver to decide whether to
+    /// pre-bundle queued user L1 txs into postBatch's bundle (atomic
+    /// inclusion) or to forward them separately after submission.
+    pub fn uses_bundle_submission(&self) -> bool {
+        self.builder_http.is_some() && self.config.l1_builder_rpc_url.is_some()
+    }
+
     /// Read the on-chain state root from the Rollups contract for this rollup.
     pub async fn last_submitted_state_root(&self) -> Result<B256> {
         let calldata = rollupsCall {
@@ -527,6 +536,15 @@ impl Proposer {
         blocks: &[PendingBlock],
         cross_chain_entries: &[CrossChainExecutionEntry],
         gas_price_hint: Option<GasPriceHint>,
+        // Pre-signed user L1 txs (e.g., bridgeEther forwards from the L1
+        // composer RPC) to include atomically with the postBatch. In bundle
+        // mode they go into the same `eth_sendBundle.txs` array as postBatch,
+        // guaranteeing they share `(parent_hash, block.timestamp)` and the
+        // contract's same-block-atomicity invariant holds. In raw mode they
+        // are ignored here — the caller forwards them separately via
+        // `forward_queued_l1_txs` (acceptable on a controlled L1 like
+        // reth --dev where the proposer drives block production).
+        bundled_user_txs: &[Bytes],
     ) -> Result<B256> {
         if blocks.is_empty() && cross_chain_entries.is_empty() {
             return Err(eyre::eyre!("nothing to submit"));
@@ -623,12 +641,26 @@ impl Proposer {
             // `eth_sendBundle` targeting `proof_ctx.target_block_number`.
             // Bundle is either included in that block or silently dropped —
             // matching the proof's committed `(parent_hash, timestamp)`.
-            self.send_via_bundle(&tx, proof_ctx.target_block_number, http, url)
-                .await
-                .map_err(|err| {
-                    warn!(target: "based_rollup::proposer", %err, "failed to submit bundle to builder RPC");
-                    err
-                })?
+            //
+            // User txs (forwarded from the L1 composer RPC) ride in the same
+            // bundle so they share `(parent_hash, block.timestamp)` with
+            // postBatch. This is the only way to guarantee
+            // `lastStateUpdateBlock == block.number` when the user's
+            // executeCrossChainCall runs — without bundling, the user tx
+            // would land in some later block via the public mempool and
+            // revert with `ExecutionNotInCurrentBlock()`.
+            self.send_via_bundle(
+                &tx,
+                proof_ctx.target_block_number,
+                http,
+                url,
+                bundled_user_txs,
+            )
+            .await
+            .map_err(|err| {
+                warn!(target: "based_rollup::proposer", %err, "failed to submit bundle to builder RPC");
+                err
+            })?
         } else {
             // Standard `eth_sendRawTransaction` path: tx enters public mempool
             // and lands in whichever block the next proposer picks it up in.
@@ -683,6 +715,12 @@ impl Proposer {
         target_block_number: u64,
         http: &reqwest::Client,
         url: &str,
+        // Additional pre-signed raw txs to include in the same bundle, after
+        // postBatch. Used for L1 user txs forwarded from the composer RPC so
+        // they share `(parent_hash, block.timestamp)` with the postBatch and
+        // satisfy the contract's `lastStateUpdateBlock == block.number`
+        // invariant in `executeCrossChainCall`.
+        additional_user_txs: &[Bytes],
     ) -> Result<B256> {
         // Fill in any fields not already supplied by the caller.
         let chain_id = self.provider.get_chain_id().await?;
@@ -771,13 +809,24 @@ impl Proposer {
         let tx_hash = *envelope.tx_hash();
 
         let raw_hex = format!("0x{}", alloy_primitives::hex::encode(&raw_bytes));
+        // Build the bundle's `txs` array: postBatch first (must run before
+        // any user tx so `lastStateUpdateBlock = block.number` is set), then
+        // forwarded user txs in order.
+        let mut bundle_txs: Vec<String> = Vec::with_capacity(1 + additional_user_txs.len());
+        bundle_txs.push(raw_hex);
+        for user_tx in additional_user_txs {
+            bundle_txs.push(format!(
+                "0x{}",
+                alloy_primitives::hex::encode(user_tx.as_ref())
+            ));
+        }
         let target_hex = format!("0x{:x}", target_block_number);
         let body = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "eth_sendBundle",
             "params": [{
-                "txs": [raw_hex],
+                "txs": bundle_txs,
                 "blockNumber": target_hex,
             }],
         });
@@ -949,7 +998,9 @@ impl Proposer {
         if blocks.is_empty() && cross_chain_entries.is_empty() {
             return Ok(0);
         }
-        let tx_hash = self.send_to_l1(blocks, cross_chain_entries, None).await?;
+        let tx_hash = self
+            .send_to_l1(blocks, cross_chain_entries, None, &[])
+            .await?;
         self.wait_for_l1_receipt(tx_hash).await
     }
 


### PR DESCRIPTION
## Problem

On real L1s (Chiado/Gnosis), the L1 composer RPC was forwarding user txs (e.g. `bridgeEther`) via `eth_sendRawTransaction` to the public mempool **after** postBatch was submitted as a bundle. The user tx and the postBatch landed in different L1 blocks — usually with the user tx 1–2 slots later than the bundle's target — so `executeCrossChainCall`'s \`lastStateUpdateBlock == block.number\` invariant failed and the contract reverted with \`ExecutionNotInCurrentBlock()\`.

Result: bridges via the L1 composer were mostly broken on real L1s. Reproduced consistently on public Chiado.

## Fix

In bundle mode, drain \`pending_l1_forward_txs\` at flush time and pass them to \`send_to_l1\`, which appends them to the same \`eth_sendBundle.txs\` array as postBatch. Bundle is atomic — both land or both drop.

- \`Proposer::send_to_l1\` and \`Proposer::send_via_bundle\` accept additional pre-signed user txs.
- \`FlushPlan::submit_via\` takes a \`bundled_user_txs: &[Bytes]\` slice.
- \`Driver::flush_to_l1\` drains the queue **only** when \`has_entries && proposer.uses_bundle_submission()\` — otherwise the queue is left intact for the legacy raw path (reth --dev) where the post-submit \`forward_queued_l1_txs\` already lands in the same block by construction.
- On submit failure, drained user txs are restored to the queue front so the next flush attempt re-bundles them.

## Validation

End-to-end deposit on public Chiado (\`deployments/chiado-10200-public/\`):
- \`bridgeEther\` user tx and \`postBatch\` land in the same L1 block.
- L2 user balance climbed by deposited amount.
- L1 \`Bridge\` custody (\`rollups(1).etherBalance\`) increased correspondingly.

## TODO

- [ ] L2→L1 withdrawal direction has a *mirror* atomicity bug. \`loadExecutionTable\` (Stage 3) only fires when there are incoming entries from L1, so a standalone L2→L1 user call lands in an L2 block that hasn't updated \`lastStateUpdateBlock\` and reverts with \`ExecutionNotInCurrentBlock()\` from \`CrossChainManagerL2\`. Will file as separate issue + fix.
- [ ] Unit/integration test that constructs a multi-tx bundle and verifies the order is \`[postBatch, ...user_txs]\`. Existing proposer tests pass but don't directly cover the new path.
- [ ] Decide whether to also bundle L2→L1 trigger txs (currently still forwarded via \`send_l2_to_l1_triggers\` post-submit) — probably another atomicity hole for symmetric reasons.